### PR TITLE
Check if directory exists for SDK (to handle symlinks correctly)

### DIFF
--- a/lib/environ.js
+++ b/lib/environ.js
@@ -89,7 +89,7 @@ os.sdkPaths.forEach(function (titaniumPath) {
 		if (afs.exists(mobilesdkPath)) {
 			fs.readdirSync(mobilesdkPath).filter(function (f) {
 				var dir = path.join(mobilesdkPath, f);
-				return fs.statSync(dir).isDirectory() && fs.readdirSync(dir).some(function (f) {
+				return afs.exists(dir) && fs.statSync(dir).isDirectory() && fs.readdirSync(dir).some(function (f) {
 					return readme.test(f);
 				});
 			}).filter(function (f) {


### PR DESCRIPTION
Handles sdk directories that are symlinks.
