### PR TITLE
Broken symlinks possible when copying symlinks with relative paths in copyDirSyncRecursive

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -173,6 +173,7 @@ exports.copyDirSyncRecursive = function(sourceDir, newDirLocation, opts) {
 			if (currFile.isSymbolicLink()) {
 				wrench.mkdirSyncRecursive(newDirLocation);
 				var symlinkFull = fs.readlinkSync(sourceDir + '/' + files[i]);
+				symlinkFull = path.resolve(sourceDir, symlinkFull);
 				fs.symlinkSync(symlinkFull, destFile);
 			} else {
 				// At this point, we've hit a file actually worth copying... so copy it on over.


### PR DESCRIPTION
- you have a file: common/foo.js
- you have another directory (not_common/stuff/) and you add a symlink in it (../../common/foo.js)
- you use copyDirSyncRecursive to copy the directory 'stuff' somewhere else (not_common/not_stuff/build/target)
- it will copy the sym link with the same relative path (../../common/foo.js) which is not valid

this fix creates an absolute path link instead
