### PR TITLE
Fixed regression for Node.js 0.10.X

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -36,6 +36,11 @@ exports.detect = function (finished, sdkPath, ndkPath) {
 	if (!sdkPath || !afs.exists(sdkPath)) {
 		sdkPath = result.sdkPath = findSDK();
 	}
+
+	if ( !sdkPath ) {
+		finished && finished();
+		return;
+	}
 	
 	var exe = result.exe = path.join(sdkPath, 'tools', process.platform == 'win32' ? 'android.bat' : 'android');
 	if (!afs.exists(exe)) {


### PR DESCRIPTION
Due to changed behavior of path.join and a wrong assumption of sdkPath being not undefined (in case of no Android SDK is installed), trying to path.join a non-string will result in breaking the whole runtime. (i.e. CLI)
