### PR TITLE
updates to be able to use auth library with other appc libraries

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -32,6 +32,14 @@ var __ = require('./i18n')(__dirname).__,
 	cachedStatus,
 	cachedMid;
 
+// common error codes for Authentication
+exports.AUTH_ERR_BAD_UN_OR_PW 		= '101';     //user name or password incorrect
+exports.AUTH_ERR_ACCT_NOT_ACTIVE    = '102';     //the account needs to be activated on appcelerator
+exports.AUTH_ERR_CONNECT_FAILURE    = '104';     //unable to reach login server
+exports.AUTH_ERR_LOGIN_SERVER_ERR   = '105';     //exception from login server
+exports.AUTH_ERR_LOGOUT_NO_LOGIN    = '106';     //logout while not logged in
+exports.AUTH_ERR_INTERNAL_SVR_ERR   = '107';     //other internal server errors
+
 /**
  * Authenticates a user into the Appcelerator Network.
  * @param {Object} args - Login arguments
@@ -74,10 +82,17 @@ exports.login = function login(args) {
 		}, function (error, response, body) {
 			try {
 				if (error) {
-					throw new Error(__('Error communicating with the server: %s', error));
+					var ex = new Error(__('Error communicating with the server: %s', error));
+					ex.code = exports.AUTH_ERR_CONNECT_FAILURE;
+					throw ex;
 				}
 
 				var res = JSON.parse(body);
+				if (res.success && !res.activated) {
+					var ex = new Error(__('Account not activated. Please activate your account before continuing.'));
+					ex.code = exports.AUTH_ERR_ACCT_NOT_ACTIVE;
+					throw ex;
+				}
 				if (res.success) {
 					var cookie = response.headers['set-cookie'];
 					if (cookie && cookie.length === 1 && cookie[0].match('^PHPSESSID')) {
@@ -85,12 +100,14 @@ exports.login = function login(args) {
 						var result = {
 							loggedIn: true,
 							cookie: cookie[0],
-							data: {
-								uid: res.uid,
-								guid: res.guid,
-								email: res.email
-							}
-						};
+							data: {}
+						},
+						omitKeys = ['success'];
+
+						// add all the result keys into the data object
+						Object.keys(res).forEach(function(k){
+							omitKeys.indexOf(k)===-1 && (result.data[k]=res[k]);
+						});
 
 						// Write the data out to the session file
 						if (!fs.existsSync(args.titaniumHomeDir)) {
@@ -100,14 +117,21 @@ exports.login = function login(args) {
 
 						args.callback(null, result);
 					} else {
-						throw new Error(__('Server did not return a session cookie'));
+						var ex = new Error(__('Server did not return a session cookie'));
+						ex.code = exports.AUTH_ERR_INTERNAL_SVR_ERR;
+						throw ex;
 					}
 				} else if (res.code === 4 || res.code === 5) {
-					throw new Error(__('Invalid username or password. If you have forgotten your password, please visit %s.', myAppc.cyan));
+					var ex = new Error(__('Invalid username or password. If you have forgotten your password, please visit %s.', myAppc.cyan));
+					ex.code = exports.AUTH_ERR_BAD_UN_OR_PW;
+					throw ex;
 				} else {
-					throw new Error(__('Invalid server response'));
+					var ex = new Error(__('Invalid server response'));
+					ex.code = exports.AUTH_ERR_LOGIN_SERVER_ERR;
+					throw ex;
 				}
 			} catch (ex) {
+				!ex.code && (ex.code = exports.AUTH_ERR_INTERNAL_SVR_ERR);
 				createLoggedOutSessionFile(args.titaniumHomeDir);
 				args.callback(ex);
 			}
@@ -215,6 +239,13 @@ exports.status = function status(args) {
 	}
 
 	return cachedStatus = result;
+};
+
+/**
+ * for testing, remove the MID
+ */
+exports.resetMID = function resetMID() {
+	cachedMid = null;
 };
 
 /**

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -45,6 +45,7 @@ exports.AUTH_ERR_INTERNAL_SVR_ERR   = '107';     //other internal server errors
  * @param {Object} args - Login arguments
  * @param {String} args.username - The email address to log in as
  * @param {String} args.password - The password
+ * @param {String} args.mid - The specific mid to use (null by default)
  * @param {Function} args.callback(error, result) - The function to call once logged in or on error
  * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
  * @param {String} [args.loginUrl] - The URL to authenticate against
@@ -53,18 +54,21 @@ exports.AUTH_ERR_INTERNAL_SVR_ERR   = '107';     //other internal server errors
 exports.login = function login(args) {
 	args || (args = {});
 	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
+	var dontWriteSession = !!(args.mid); // if we have a passed in mid, don't write it
 
-	try {
-		assertSessionFile(args.titaniumHomeDir);
-	} catch (ex) {
-		args.callback(ex);
-		return;
+	if (!dontWriteSession) {
+		try {
+			assertSessionFile(args.titaniumHomeDir);
+		} catch (ex) {
+			args.callback(ex);
+			return;
+		}
 	}
 
 	cachedStatus = null;
 	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json');
 
-	exports.getMID(args.titaniumHomeDir, function (mid) {
+	exports.getMID(args.titaniumHomeDir, args.mid, function (mid) {
 		// Otherwise we need to re-auth with the server
 		request({
 			uri: args.loginUrl || defaultLoginUrl,
@@ -109,11 +113,13 @@ exports.login = function login(args) {
 							omitKeys.indexOf(k)===-1 && (result.data[k]=res[k]);
 						});
 
-						// Write the data out to the session file
-						if (!fs.existsSync(args.titaniumHomeDir)) {
-							wrench.mkdirSyncRecursive(args.titaniumHomeDir);
+						if (!dontWriteSession) {
+							// Write the data out to the session file
+							if (!fs.existsSync(args.titaniumHomeDir)) {
+								wrench.mkdirSyncRecursive(args.titaniumHomeDir);
+							}
+							fs.writeFileSync(sessionFile, JSON.stringify(result));
 						}
-						fs.writeFileSync(sessionFile, JSON.stringify(result));
 
 						args.callback(null, result);
 					} else {
@@ -132,7 +138,7 @@ exports.login = function login(args) {
 				}
 			} catch (ex) {
 				!ex.code && (ex.code = exports.AUTH_ERR_INTERNAL_SVR_ERR);
-				createLoggedOutSessionFile(args.titaniumHomeDir);
+				!dontWriteSession && createLoggedOutSessionFile(args.titaniumHomeDir);
 				args.callback(ex);
 			}
 		});
@@ -252,11 +258,12 @@ exports.resetMID = function resetMID() {
  * Returns the machine id (mid) or generates a new one based on the computer's
  * primary network interface's MAC address.
  * @param {String} titaniumHomeDir - The Titanium home directory where the session files are stored
+ * @param {String} mid - A cached mid to use if provided during login, defaults to null
  * @param {Function} callback - A callback to fire with the result
  */
-exports.getMID = function getMID(titaniumHomeDir, callback) {
-	if (cachedMid) {
-		callback(cachedMid);
+exports.getMID = function getMID(titaniumHomeDir, mid, callback) {
+	if (cachedMid||mid) {
+		callback(cachedMid||mid);
 	} else {
 		var midFile = path.join(titaniumHomeDir, 'mid.json');
 		if (fs.existsSync(midFile)) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -33,12 +33,12 @@ var __ = require('./i18n')(__dirname).__,
 	cachedMid;
 
 // common error codes for Authentication
-exports.AUTH_ERR_BAD_UN_OR_PW 		= '101';     //user name or password incorrect
-exports.AUTH_ERR_ACCT_NOT_ACTIVE    = '102';     //the account needs to be activated on appcelerator
-exports.AUTH_ERR_CONNECT_FAILURE    = '104';     //unable to reach login server
-exports.AUTH_ERR_LOGIN_SERVER_ERR   = '105';     //exception from login server
-exports.AUTH_ERR_LOGOUT_NO_LOGIN    = '106';     //logout while not logged in
-exports.AUTH_ERR_INTERNAL_SVR_ERR   = '107';     //other internal server errors
+exports.AUTH_ERR_BAD_UN_OR_PW 		= 'AUTH_ERR_BAD_UN_OR_PW';     		//user name or password incorrect
+exports.AUTH_ERR_ACCT_NOT_ACTIVE    = 'AUTH_ERR_ACCT_NOT_ACTIVE';     	//the account needs to be activated on appcelerator
+exports.AUTH_ERR_CONNECT_FAILURE    = 'AUTH_ERR_CONNECT_FAILURE';     	//unable to reach login server
+exports.AUTH_ERR_LOGIN_SERVER_ERR   = 'AUTH_ERR_LOGIN_SERVER_ERR';     	//exception from login server
+exports.AUTH_ERR_LOGOUT_NO_LOGIN    = 'AUTH_ERR_LOGOUT_NO_LOGIN';     	//logout while not logged in
+exports.AUTH_ERR_INTERNAL_SVR_ERR   = 'AUTH_ERR_INTERNAL_SVR_ERR';     	//other internal server errors
 
 /**
  * Authenticates a user into the Appcelerator Network.
@@ -262,6 +262,10 @@ exports.resetMID = function resetMID() {
  * @param {Function} callback - A callback to fire with the result
  */
 exports.getMID = function getMID(titaniumHomeDir, mid, callback) {
+	if (typeof mid === 'function') {
+		callback = mid;
+		mid = null;
+	}
 	if (cachedMid||mid) {
 		callback(cachedMid||mid);
 	} else {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"mocha": "*",
-		"should": "*"
+		"should": "~1.3.0"
 	},
 	"license":"Apache Public License v2",
 	"main": "./index",

--- a/tests/test-auth.js
+++ b/tests/test-auth.js
@@ -19,7 +19,37 @@ describe('auth', function () {
 	});
 
 	describe('#login()', function () {
-		//
+		it('should fail with invalid login', function(done){
+			// test invalid login
+			this.timeout(30000);
+			appc.auth.login({
+				username: 'appctestlogin1234@appcelerator.com',
+				password: 'whoknows',
+				titaniumHomeDir: temp.mkdirSync(),	
+				callback: function(result) {
+					result.should.have.property('code');
+					result.code.should.equal(appc.auth.AUTH_ERR_BAD_UN_OR_PW);
+					appc.auth.resetMID();
+					done();
+				}
+			});
+		});
+		it('should fail with invalid url', function(done){
+			// test invalid login url
+			this.timeout(10000);
+			appc.auth.login({
+				loginUrl: 'http://monkeyfart.fooasdadsasdasda.com',
+				username: 'appctestlogin1234@appcelerator.com',
+				password: 'whoknows',
+				titaniumHomeDir: temp.mkdirSync(),	
+				callback: function(result) {
+					result.should.have.property('code');
+					result.code.should.equal(appc.auth.AUTH_ERR_CONNECT_FAILURE);
+					appc.auth.resetMID();
+					done();
+				}
+			});
+		});
 	});
 
 	describe('#logout()', function () {


### PR DESCRIPTION
Added some improvements to allow this common auth library to be usable by node-acs.

- added standard auth codes as part of exceptions used by node-acs (and good practice)
- added additional meta data from login result to be able to be used (such as firstname, etc)
- added additional unit tests for auth login
- fixed unit test failures by specifying older should version. newer should.js library doesn't support same syntax as we are using
