### PR TITLE
Guard cursorTo

### DIFF
--- a/lib/busyindicator.js
+++ b/lib/busyindicator.js
@@ -37,7 +37,7 @@ function BusyIndicator(opts) {
  */
 BusyIndicator.prototype.start = function start() {
 	var render = function () {
-		process.stdout.cursorTo(0);
+		process.stdout.cursorTo && process.stdout.cursorTo(0);
 		process.stdout.write(this.margin + this.sprites[this.current++]);
 		if (this.current >= this.sprites.length) {
 			this.current = 0;
@@ -58,9 +58,9 @@ BusyIndicator.prototype.stop = function stop() {
 	clearTimeout(this._timer);
 	if (this._running) {
 		this._running = false;
-		process.stdout.cursorTo(0);
+		process.stdout.cursorTo && process.stdout.cursorTo(0);
 		process.stdout.write(new Array(this.margin.length + 2).join(' '));
-		process.stdout.cursorTo(0);
+		process.stdout.cursorTo && process.stdout.cursorTo(0);
 	}
 };
 

--- a/lib/progress.js
+++ b/lib/progress.js
@@ -118,7 +118,7 @@ ProgressBar.prototype.tick = function tick(len, tokens) {
 			this.writePending = true;
 			setTimeout(function () {
 				this.writePending = false;
-				process.stdout.cursorTo(0);
+				process.stdout.cursorTo && process.stdout.cursorTo(0);
 				process.stdout.write(this.str);
 			}.bind(this), 30);
 		}

--- a/tests/test-progress.js
+++ b/tests/test-progress.js
@@ -17,7 +17,7 @@ describe('progress', function () {
 		this.slow('3s');
 
 		var origWrite = process.stdout.write,
-			origCursorTo = process.stdout.cursorTo,
+			origCursorTo = process.stdout.cursorTo || function () {},
 			buffer = '';
 
 		process.stdout.write = function (s) {
@@ -62,7 +62,7 @@ describe('progress', function () {
 		this.slow('3s');
 
 		var origWrite = process.stdout.write,
-			origCursorTo = process.stdout.cursorTo,
+			origCursorTo = process.stdout.cursorTo || function () {},
 			buffer = '';
 
 		process.stdout.write = function (s) {
@@ -107,7 +107,7 @@ describe('progress', function () {
 		this.slow('3s');
 
 		var origWrite = process.stdout.write,
-			origCursorTo = process.stdout.cursorTo,
+			origCursorTo = process.stdout.cursorTo || function () {},
 			buffer = '';
 
 		process.stdout.write = function (s) {


### PR DESCRIPTION
It seems to be undefined in some environments. As this method isn't critical to a program functioning, but an undefined crash is, let's guard it.
