### PR TITLE
fixed modules zip lookup

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -271,13 +271,14 @@ function detectModules(searchPaths, config, logger, callback) {
 			var moduleRoot = root,
 				tasks = [];
 
+			var pathToLookForModules = path.join(root, '..');
 			// auto-install zipped modules
-			fs.readdirSync(root).forEach(function (file) {
-				var moduleZip = path.join(root, file);
+			fs.readdirSync(pathToLookForModules).forEach(function (file) {
+				var moduleZip = path.join(pathToLookForModules, file);
 				if (fs.existsSync(moduleZip) && fs.statSync(moduleZip).isFile() && zipRegExp.test(file)) {
 					tasks.push(function (taskDone) {
 						logger && logger.info(__('Installing module: %s', file));
-						zip.unzip(moduleZip, root, null, function (err) {
+						zip.unzip(moduleZip, pathToLookForModules, null, function (err) {
 							if (err) {
 								logger && logger.error(__('Failed to unzip module "%s"', moduleZip));
 							} else {


### PR DESCRIPTION
In the newest cli you look for modules directly in the "modules" directory. Consequently you also look for zip files inside that dir, which is not what we add before.
There were 2 choices:
-  change so that we now have to put modules zips inside that modules dir
- look for zip files one dir up

I chose the second one because:
- dont need to change the "unzip" method which unzips in the same dir. Plus it creates another subdir "modules"
- we dont change the behavior 
