### PR TITLE
look for modules in config.paths.modules

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -136,7 +136,7 @@ exports.find = function find(modules, platforms, deployType, sdkVersion, searchP
 	exports.detect(searchPaths, config, logger, function (installed) {
 		modules.forEach(function (module) {
 			var originalVersion = module.version || 'latest',
-				scopes = ['project', 'global'],
+				scopes = ['project', 'user', 'global'],
 				i, j, scope, info, platform, found, ver, tmp;
 
 			// make sure the module has a valid array of platforms


### PR DESCRIPTION
I dont know if there is a reason why you did it for plugins and not for modules, but i find it really useful!
Obviously it goes with a PR in Ti SDK. If you want this one i ll make the PR
