### PR TITLE
TIMOB-17544 CLI: Log users into dashboard.appcelerator.com

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,11 +1,11 @@
 /**
- * Performs authentication tasks including logging in the Appcelerator Network,
+ * Performs authentication tasks including logging in the Appcelerator Platform,
  * logging out, and checking session status.
  *
  * @module auth
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -15,22 +15,14 @@
 var __ = require('./i18n')(__dirname).__,
 	fs = require('fs'),
 	path = require('path'),
-	crypto = require('crypto'),
 	uuid = require('node-uuid'),
 	wrench = require('wrench'),
 	request = require('request'),
-	net = require('./net'),
-	mix = require('./util').mix,
-	afs = require('./fs'),
-	AppcException = require('./exception'),
+	authApiServer = require('./authapiserver'),
 
-	defaultTitaniumHomeDir = afs.resolvePath('~', '.titanium'),
-	defaultLoginUrl = 'https://api.appcelerator.com/p/v1/sso-login',
-	defaultLogoutUrl = 'https://api.appcelerator.com/p/v1/sso-logout',
-	myAppc = 'https://my.appcelerator.com/',
+	defaultDashboardHost = "https://dashboard.appcelerator.com",
+	defaultDashboardAuthPath = "/api/v1/auth/login";
 
-	cachedStatus,
-	cachedMid;
 
 /**
  * Authenticates a user into the Appcelerator Network.
@@ -44,22 +36,14 @@ var __ = require('./i18n')(__dirname).__,
  */
 exports.login = function login(args) {
 	args || (args = {});
-	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
 
-	try {
-		assertSessionFile(args.titaniumHomeDir);
-	} catch (ex) {
-		args.callback(ex);
-		return;
-	}
+	var dashboardHost = args.dashboardHost || defaultDashboardHost;
+    var dashboardLoginUrl =  dashboardHost + defaultDashboardAuthPath;
 
-	cachedStatus = null;
-	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json');
+    var cb = args.callback || {};
 
-	exports.getMID(args.titaniumHomeDir, function (mid) {
-		// Otherwise we need to re-auth with the server
-		request({
-			uri: args.loginUrl || defaultLoginUrl,
+    request({
+			uri: dashboardLoginUrl,
 			method: 'POST',
 			proxy: args.proxy,
 			jar: false, // don't save cookies
@@ -68,156 +52,162 @@ exports.login = function login(args) {
 			},
 			rejectUnauthorized: args.rejectUnauthorized === undefined ? true : !!args.rejectUnauthorized,
 			body: net.urlEncode({
-				un: args.username,
-				pw: args.password,
-				mid: mid
+				username: args.username,
+				password: args.password
 			})
 		}, function (error, response, body) {
-			try {
-				if (error) {
-					throw new Error(__('Error communicating with the server: %s', error));
-				}
-
-				var res = JSON.parse(body);
-				if (res.success) {
-					var cookie = response.headers['set-cookie'];
-					if (cookie && cookie.length === 1 && cookie[0].match('^PHPSESSID')) {
-						// Create the result
-						var result = {
-							loggedIn: true,
-							cookie: cookie[0],
-							data: {
-								uid: res.uid,
-								guid: res.guid,
-								email: res.email
-							}
-						};
-
-						// Write the data out to the session file
-						if (!fs.existsSync(args.titaniumHomeDir)) {
-							wrench.mkdirSyncRecursive(args.titaniumHomeDir);
-						}
-						fs.writeFileSync(sessionFile, JSON.stringify(result));
-
-						args.callback(null, result);
-					} else {
-						throw new Error(__('Server did not return a session cookie'));
-					}
-				} else if (res.code === 4 || res.code === 5) {
-					throw new Error(__('Invalid username or password. If you have forgotten your password, please visit %s.', myAppc.cyan));
-				} else {
-					throw new Error(__('Invalid server response'));
-				}
-			} catch (ex) {
-				createLoggedOutSessionFile(args.titaniumHomeDir);
-				args.callback(ex);
-			}
-		});
-	});
-};
-
-/**
- * Logs the user out of the Appcelerator Network.
- * @param {Object} args - Logout arguments
- * @param {Function} args.callback(error, result) - The function to call once logged out or on error
- * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
- * @param {String} [args.logoutUrl] - The URL to use to end session
- * @param {String} [args.proxy] - The proxy server to use
- */
-exports.logout = function logout(args) {
-	args || (args = {});
-	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
-
-	try {
-		assertSessionFile(args.titaniumHomeDir);
-	} catch (ex) {
-		args.callback(ex);
-		return;
-	}
-
-	cachedStatus = null;
-	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json');
-
-	if (!fs.existsSync(sessionFile)) {
-		// Create a default (logged out) session file
-		args.callback(null, mix(createLoggedOutSessionFile(sessionFile), { success: true, alreadyLoggedOut: true }));
-		return;
-	}
-
-	try {
-		var session = JSON.parse(fs.readFileSync(sessionFile));
-		if (session.loggedIn) {
-			request({
-				uri: args.logoutUrl || defaultLogoutUrl,
-				method: 'GET',
-				proxy: args.proxy,
-				headers: {
-					'Cookie': session.cookie
-				},
-				rejectUnauthorized: args.rejectUnauthorized === undefined ? true : !!args.rejectUnauthorized
-			}, function (error, response, body) {
-				var result = createLoggedOutSessionFile(sessionFile);
 				try {
 					if (error) {
-						throw new Error(__('Error communicating with the server: %s', error));
+						throw new Error(__('Error communicating with the Appcelerator Platform server: %s', error));
 					}
 
-					var res = JSON.parse(body);
-					if (res.success) {
-						mix(result, { success: true, alreadyLoggedOut: false });
-					} else {
-						throw new Error(__('Error logging out from server: %s', res.reason));
-					}
+					if (response.statusCode == 200) {
+		                try {
+		                    var result = JSON.parse(body);
+		                } catch (e) {
+		                    return cb(__('Bad response from Appcelerator Platform server: ') + body, null);
+		                }
+		                if (result.success) {
+		                    // Find sid from the cookies header.
+		                    var cookies = response.headers['set-cookie'];
+		                    if(!cookies) {
+		                        return cb(__('Bad response from Appcelerator Platform : No cookie info'), null);
+		                    }
 
-					args.callback(null, result);
+		                    var sid = null;
+		                    cookies.forEach(function(cookie) {
+		                        if(cookie.indexOf('connect.sid=') !== 0) {
+		                            return;
+		                    	}
+		                        sid = (cookie+'').split(';')[0].split('=')[1];
+		                    });
+
+		                    // add logged in appcelerator platform server details and new API server details to the args.
+		                    if (result.result && result.result.apiServer)
+		                    {
+		                 	   args.loginUrl = result.result.apiServer;
+		                	}
+		                    args.dashboardHost = dashboardHost;
+		                    args.sid = sid; 
+		                    authApiServer.login(args);
+
+		                    // Write the organization details into the 360 session file.
+		                    exports.getOrganizations(args);
+		                } else {
+		                    cb(__('Invalid Appcelerator 360 User: ') + result.description || '', null);
+		                }
+		            } else if (response.statusCode == 400) {
+		                // invalid login, authentication error
+		                cb(__('Invalid login: ') + result.description||'', null);
+
+		            } else {
+		                cb(__('Invalid response code (' + res.statusCode + ') from Appcelerator 360.'), null);
+		            }
 				} catch (ex) {
-					args.callback(ex, result);
+					args.callback(ex);
 				}
-			});
-		} else {
-			args.callback(null, mix(session, { success: true, alreadyLoggedOut: true }));
-		}
-	} catch (ex) { // Invalid session file. This should never happen
-		args.callback(ex, mix(createLoggedOutSessionFile(sessionFile), { success: true, alreadyLoggedOut: true }));
-	}
+		});
 };
+
+
+/**
+ * Retrieves the organization details of the user from the Appcelerator Platform. This will return the json array 
+ * containing the list of organization's id and name.
+ *
+ * @param {Object} args - Organization arguments
+ * @param {String} [args.username] email of the user currently logging in
+ * @param {String} [args.sid] session id from dashboard
+ * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
+ * @param {String} [args.proxy] - The proxy server to use
+ * @param {Function} args.callback(error, result) - The function to call once logged out or on error
+ */
+exports.getOrganizations = function getOrganizations(args) {
+
+    var cb = args.callback || {};
+	var session = authApiServer.getSessionInfo();
+	if (!session.loggedIn)
+	{
+		// Don't do anything for now, if the user is not logged in.
+		cb(null, {"loggedIn": false});
+	}
+	var dashboardHost = (session.data ? session.data.dashboardHost : undefined) || defaultDashboardHost;
+
+    var url = dashboardHost + "/api/v1/user/organizations";
+
+    //curl -i -b connect.sid=s%3AaJaL7IWQ_cDvmVBeQRY997hf.vVzLV2aFvrYiEKmfdTARTuHessesQ0Xm87JvFESaus http://dashboard.appcelerator.com/api/v1/user/organizations
+    request({
+			uri: url,
+			method: 'GET',
+			proxy: args.proxy,
+			headers: {
+				'Cookie': 'connect.sid=' + args.sid,
+        		'Content-Type': 'application/x-www-form-urlencoded'
+			}
+		}, function (error, response, body) {
+				try {
+					if (error) {
+						throw new Error(__('Error communicating with the Appcelerator Platform server: %s', error));
+					}
+
+					if (response.statusCode == 200) {
+		                try {
+		                    var result = JSON.parse(body);
+		                } catch (e) {
+		                    return cb(__('Bad response for user organization info from Appcelerator 360: ') + data, null);
+		                }
+		                if (result.success) {
+		                    if(!result.result || Object.prototype.toString.call(result.result) !== '[object Array]' || result.result.length == 0) {
+		                        return cb(__("Bad response from Appcelerator 360: no organization info. ") + result, null);
+		                    }
+
+		                    var orgs = [];
+		                    result.result.forEach(function(orgDoc) {
+		                        var org = {};
+		                        org.id = orgDoc.org_id;
+		                        org.name = orgDoc.name;
+		                        orgs.push(org);
+		                    });
+
+		                    var appcSession = {
+		                    	"orgs" : orgs,
+		                    	"sid" : args.sid,
+		                    	"username": args.username
+		                    };
+
+		                    // Write orgs information to session file.
+		                    var titaniumHomeDir = authApiServer.getTitaniumHomeDir(args);
+		                    var appcSessionFile = path.join(titaniumHomeDir, 'appc_session.json');
+		                    fs.writeFile(appcSessionFile, JSON.stringify(appcSession), cb(null, null));
+
+		                    return orgs;
+		                } else {
+		                    cb(__("Failed to get organization information. ") + result.description || '', null);
+		                }
+		            } else if (response.statusCode == 400) {
+		                // invalid login, authentication error
+		                cb(__("Failed to get organization information. ") + result.description || '', null);
+
+		            } else {
+		                console.log("Invalid response code (" + res.statusCode + ") from Appcelerator 360.")
+		                cb(__("Invalid response code from Appcelerator Platform Server: ") + res.statusCode, null);
+		            }
+				} catch (ex) {
+					cb(ex);
+				}
+		});
+}
 
 /**
  * Returns whether the user is current logged in.
+ *
  * @param {Object} [args] - Status arguments
  * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
  * @returns {Object} An object containing the session status
  */
 exports.status = function status(args) {
-	if (cachedStatus) return cachedStatus;
-
-	args || (args = {});
-	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
-
-	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json'),
-		result = {},
-		session;
-
-	if (fs.existsSync(sessionFile)) {
-		try {
-			// Fetch and parse the session data
-			session = JSON.parse(fs.readFileSync(sessionFile));
-			result = {
-				loggedIn: session.loggedIn,
-				uid: session.data && session.data.uid,
-				guid: session.data && session.data.guid,
-				email: session.data && session.data.email,
-				cookie: session.cookie
-			};
-		} catch (e) { // Invalid session file. This should never happen
-			result = createLoggedOutSessionFile(sessionFile);
-		}
-	} else {
-		result = createLoggedOutSessionFile(sessionFile); // No prior history, create a new logged out file
-	}
-
-	return cachedStatus = result;
-};
+	//TODO: List organization details of the Appcelerator platform user.
+	authApiServer.status(args);
+}
 
 /**
  * Returns the machine id (mid) or generates a new one based on the computer's
@@ -226,83 +216,35 @@ exports.status = function status(args) {
  * @param {Function} callback - A callback to fire with the result
  */
 exports.getMID = function getMID(titaniumHomeDir, callback) {
-	if (cachedMid) {
-		callback(cachedMid);
-	} else {
-		var midFile = path.join(titaniumHomeDir, 'mid.json');
-		if (fs.existsSync(midFile)) {
-			try {
-				cachedMid = JSON.parse(fs.readFileSync(midFile)).mid;
-				if (cachedMid) {
-					callback(cachedMid);
-					return;
-				}
-			} catch (e) {} // File/MID entry doesn't exist, so we need to recreate it
-		}
-
-		// If it got here, we couldn't fetch the previous MID
-		net.interfaces(function (ifaces) {
-			// Find the MAC address of the local ethernet card
-			var macAddress,
-				names = Object.keys(ifaces).sort(),
-				i, j;
-
-			for (i = 0; i < names.length; i++) {
-				j = ifaces[names[i]];
-				if (j.macAddress) {
-					macAddress = j.macAddress;
-					if (/^eth|en|Local Area Connection/.test(j)) {
-						break;
-					}
-				}
-			}
-
-			macAddress || (macAddress = uuid.v4());
-
-			// Create the MID, using the MAC address as a seed
-			cachedMid = crypto.createHash('md5').update(macAddress).digest('hex');
-
-			// Write the MID to its file
-			if (!fs.existsSync(titaniumHomeDir)) {
-				wrench.mkdirSyncRecursive(titaniumHomeDir);
-			}
-			fs.writeFileSync(midFile, JSON.stringify({ mid: cachedMid }));
-
-			callback(cachedMid);
-		});
-	}
-};
-
-/**
- * Asserts the session file exists that the file is writable or the session file
- * does not exist and the Titanium home directory is writable.
- * @param {String} titaniumHomeDir - The Titanium home directory where the session files are stored
- * @throws {AppcException} If session file or Titanium home directory is not writable
- * @private
- */
-function assertSessionFile(titaniumHomeDir) {
-	var sessionFile = path.join(titaniumHomeDir, 'auth_session.json');
-
-	// check that the file is writable
-	if (fs.existsSync(sessionFile)) {
-		if (!afs.isFileWritable(sessionFile)) {
-			throw new AppcException(__('Session file "%s" is not writable', sessionFile), __('Please ensure the Titanium CLI has access to modify this file.'));
-		}
-
-	// check that the .titanium folder is writable
-	} else if (fs.existsSync(titaniumHomeDir) && !afs.isDirWritable(titaniumHomeDir)) {
-		throw new AppcException(__('Directory "%s" is not writable', titaniumHomeDir), __('Please ensure the Titanium CLI has access to this directory.'));
-	}
+	authApiServer.getMID(titaniumHomeDir, callback);
 }
 
 /**
- * Creates the session file with a logged out status.
+ * Logs the user out of the Appcelerator Platform and API server.
+ *
+ * @param {Object} args - Logout arguments
+ * @param {Function} args.callback(error, result) - The function to call once logged out or on error
+ * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
+ * @param {String} [args.logoutUrl] - The URL to use to end session
+ * @param {String} [args.proxy] - The proxy server to use
+ */
+exports.logout = function logout(args) {
+	var titaniumHomeDir = authApiServer.getTitaniumHomeDir(args);
+	var appcSessionFile = path.join(titaniumHomeDir, 'appc_session.json');
+
+	createLoggedOutAppcSessionFile(appcSessionFile);
+	authApiServer.logout(args);
+}
+
+/**
+ * Creates the session file with a logged out status for Appcelerator Platform.
+ *
  * @param {String} sessionFile - Path to the session file.
  * @returns {Object} An object contain the logged out session status
  * @private
  */
-function createLoggedOutSessionFile(sessionFile) {
-	var result = { loggedIn: false },
+function createLoggedOutAppcSessionFile(sessionFile) {
+	var result = {},
 		titaniumHomeDir = path.dirname(sessionFile),
 		session, loggedIn;
 	try {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,11 +1,11 @@
 /**
- * Performs authentication tasks including logging in the Appcelerator Platform,
+ * Performs authentication tasks including logging in the Appcelerator Network,
  * logging out, and checking session status.
  *
  * @module auth
  *
  * @copyright
- * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -21,7 +21,9 @@ var __ = require('./i18n')(__dirname).__,
 	authApiServer = require('./authapiserver'),
 
 	defaultDashboardHost = "https://dashboard.appcelerator.com",
-	defaultDashboardAuthPath = "/api/v1/auth/login";
+	defaultDashboardAuthPath = "/api/v1/auth/login",
+
+	cachedOrgs;
 
 
 /**
@@ -38,11 +40,11 @@ exports.login = function login(args) {
 	args || (args = {});
 
 	var dashboardHost = args.dashboardHost || defaultDashboardHost;
-    var dashboardLoginUrl =  dashboardHost + defaultDashboardAuthPath;
+	var dashboardLoginUrl =  dashboardHost + defaultDashboardAuthPath;
 
-    var cb = args.callback || {};
+	var cb = args.callback || {};
 
-    request({
+	request({
 			uri: dashboardLoginUrl,
 			method: 'POST',
 			proxy: args.proxy,
@@ -62,47 +64,47 @@ exports.login = function login(args) {
 					}
 
 					if (response.statusCode == 200) {
-		                try {
-		                    var result = JSON.parse(body);
-		                } catch (e) {
-		                    return cb(__('Bad response from Appcelerator Platform server: ') + body, null);
-		                }
-		                if (result.success) {
-		                    // Find sid from the cookies header.
-		                    var cookies = response.headers['set-cookie'];
-		                    if(!cookies) {
-		                        return cb(__('Bad response from Appcelerator Platform : No cookie info'), null);
-		                    }
+						try {
+							var result = JSON.parse(body);
+						} catch (e) {
+							return cb(__('Bad response from Appcelerator Platform server: ') + body, null);
+						}
+						if (result.success) {
+							// Find sid from the cookies header.
+							var cookies = response.headers['set-cookie'];
+							if(!cookies) {
+								return cb(__('Bad response from Appcelerator Platform : No cookie info'), null);
+							}
 
-		                    var sid = null;
-		                    cookies.forEach(function(cookie) {
-		                        if(cookie.indexOf('connect.sid=') !== 0) {
-		                            return;
-		                    	}
-		                        sid = (cookie+'').split(';')[0].split('=')[1];
-		                    });
+							var sid = null;
+							cookies.forEach(function(cookie) {
+								if(cookie.indexOf('connect.sid=') !== 0) {
+									return;
+								}
+								sid = (cookie+'').split(';')[0].split('=')[1];
+							});
 
-		                    // add logged in appcelerator platform server details and new API server details to the args.
-		                    if (result.result && result.result.apiServer)
-		                    {
-		                 	   args.loginUrl = result.result.apiServer;
-		                	}
-		                    args.dashboardHost = dashboardHost;
-		                    args.sid = sid; 
-		                    authApiServer.login(args);
+							// add logged in appcelerator platform server details and new API server details to the args.
+							if (result.result && result.result.apiServer)
+							{
+							   args.loginUrl = result.result.apiServer;
+							}
+							args.dashboardHost = dashboardHost;
+							args.sid = sid; 
+							authApiServer.login(args);
 
-		                    // Write the organization details into the 360 session file.
-		                    exports.getOrganizations(args);
-		                } else {
-		                    cb(__('Invalid Appcelerator 360 User: ') + result.description || '', null);
-		                }
-		            } else if (response.statusCode == 400) {
-		                // invalid login, authentication error
-		                cb(__('Invalid login: ') + result.description||'', null);
+							// Write the organization details into the 360 session file.
+							exports.getOrganizations(args);
+						} else {
+							cb(__('Invalid Appcelerator 360 User: ') + result.description || '', null);
+						}
+					} else if (response.statusCode == 400) {
+						// invalid login, authentication error
+						cb(__('Invalid login: ') + result.description||'', null);
 
-		            } else {
-		                cb(__('Invalid response code (' + res.statusCode + ') from Appcelerator 360.'), null);
-		            }
+					} else {
+						cb(__('Invalid response code (' + res.statusCode + ') from Appcelerator 360.'), null);
+					}
 				} catch (ex) {
 					args.callback(ex);
 				}
@@ -123,7 +125,24 @@ exports.login = function login(args) {
  */
 exports.getOrganizations = function getOrganizations(args) {
 
-    var cb = args.callback || {};
+	if (cachedOrgs) {
+		callback(cachedOrgs);
+	} else {
+		var titaniumHomeDir = authApiServer.getTitaniumHomeDir(args);
+		var appcSessionFile = path.join(titaniumHomeDir, 'appc_session.json');
+		if (fs.existsSync(appcSessionFile)) {
+			try {
+				cachedOrgs = JSON.parse(fs.readFileSync(appcSession)).orgs;
+				if (cachedOrgs) {
+					callback(cachedOrgs);
+					return;
+				}
+			} catch (e) {} // Appc session file or orgs entry doesn't exist, so we need to recreate it
+		}
+	}
+
+
+	var cb = args.callback || {};
 	var session = authApiServer.getSessionInfo();
 	if (!session.loggedIn)
 	{
@@ -132,16 +151,16 @@ exports.getOrganizations = function getOrganizations(args) {
 	}
 	var dashboardHost = (session.data ? session.data.dashboardHost : undefined) || defaultDashboardHost;
 
-    var url = dashboardHost + "/api/v1/user/organizations";
+	var url = dashboardHost + "/api/v1/user/organizations";
 
-    //curl -i -b connect.sid=s%3AaJaL7IWQ_cDvmVBeQRY997hf.vVzLV2aFvrYiEKmfdTARTuHessesQ0Xm87JvFESaus http://dashboard.appcelerator.com/api/v1/user/organizations
-    request({
+	//curl -i -b connect.sid=s%3AaJaL7IWQ_cDvmVBeQRY997hf.vVzLV2aFvrYiEKmfdTARTuHessesQ0Xm87JvFESaus http://dashboard.appcelerator.com/api/v1/user/organizations
+	request({
 			uri: url,
 			method: 'GET',
 			proxy: args.proxy,
 			headers: {
 				'Cookie': 'connect.sid=' + args.sid,
-        		'Content-Type': 'application/x-www-form-urlencoded'
+				'Content-Type': 'application/x-www-form-urlencoded'
 			}
 		}, function (error, response, body) {
 				try {
@@ -150,47 +169,47 @@ exports.getOrganizations = function getOrganizations(args) {
 					}
 
 					if (response.statusCode == 200) {
-		                try {
-		                    var result = JSON.parse(body);
-		                } catch (e) {
-		                    return cb(__('Bad response for user organization info from Appcelerator 360: ') + data, null);
-		                }
-		                if (result.success) {
-		                    if(!result.result || Object.prototype.toString.call(result.result) !== '[object Array]' || result.result.length == 0) {
-		                        return cb(__("Bad response from Appcelerator 360: no organization info. ") + result, null);
-		                    }
+						try {
+							var result = JSON.parse(body);
+						} catch (e) {
+							return cb(__('Bad response for user organization info from Appcelerator 360: ') + data, null);
+						}
+						if (result.success) {
+							if(!result.result || Object.prototype.toString.call(result.result) !== '[object Array]' || result.result.length == 0) {
+								return cb(__("Bad response from Appcelerator 360: no organization info. ") + result, null);
+							}
 
-		                    var orgs = [];
-		                    result.result.forEach(function(orgDoc) {
-		                        var org = {};
-		                        org.id = orgDoc.org_id;
-		                        org.name = orgDoc.name;
-		                        orgs.push(org);
-		                    });
+							var orgs = [];
+							result.result.forEach(function(orgDoc) {
+								var org = {};
+								org.id = orgDoc.org_id;
+								org.name = orgDoc.name;
+								orgs.push(org);
+							});
 
-		                    var appcSession = {
-		                    	"orgs" : orgs,
-		                    	"sid" : args.sid,
-		                    	"username": args.username
-		                    };
+							var appcSession = {
+								"orgs" : orgs,
+								"sid" : args.sid,
+								"username": args.username
+							};
 
-		                    // Write orgs information to session file.
-		                    var titaniumHomeDir = authApiServer.getTitaniumHomeDir(args);
-		                    var appcSessionFile = path.join(titaniumHomeDir, 'appc_session.json');
-		                    fs.writeFile(appcSessionFile, JSON.stringify(appcSession), cb(null, null));
+							// Write orgs information to session file.
+							var titaniumHomeDir = authApiServer.getTitaniumHomeDir(args);
+							var appcSessionFile = path.join(titaniumHomeDir, 'appc_session.json');
+							fs.writeFile(appcSessionFile, JSON.stringify(appcSession), cb(null, null));
 
-		                    return orgs;
-		                } else {
-		                    cb(__("Failed to get organization information. ") + result.description || '', null);
-		                }
-		            } else if (response.statusCode == 400) {
-		                // invalid login, authentication error
-		                cb(__("Failed to get organization information. ") + result.description || '', null);
+							return orgs;
+						} else {
+							cb(__("Failed to get organization information. ") + result.description || '', null);
+						}
+					} else if (response.statusCode == 400) {
+						// invalid login, authentication error
+						cb(__("Failed to get organization information. ") + result.description || '', null);
 
-		            } else {
-		                console.log("Invalid response code (" + res.statusCode + ") from Appcelerator 360.")
-		                cb(__("Invalid response code from Appcelerator Platform Server: ") + res.statusCode, null);
-		            }
+					} else {
+						console.log("Invalid response code (" + res.statusCode + ") from Appcelerator 360.")
+						cb(__("Invalid response code from Appcelerator Platform Server: ") + res.statusCode, null);
+					}
 				} catch (ex) {
 					cb(ex);
 				}

--- a/lib/authapiserver.js
+++ b/lib/authapiserver.js
@@ -1,0 +1,354 @@
+/**
+ * Performs authentication tasks including logging in the Appcelerator Network,
+ * logging out, and checking session status.
+ *
+ * @module auth
+ *
+ * @copyright
+ * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ *
+ * @license
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+var __ = require('./i18n')(__dirname).__,
+	fs = require('fs'),
+	path = require('path'),
+	crypto = require('crypto'),
+	uuid = require('node-uuid'),
+	wrench = require('wrench'),
+	request = require('request'),
+	net = require('./net'),
+	mix = require('./util').mix,
+	afs = require('./fs'),
+	AppcException = require('./exception'),
+
+	defaultTitaniumHomeDir = afs.resolvePath('~', '.titanium'),
+	defaultLoginUrl = 'https://api.appcelerator.com/p/v1/sso-login',
+	defaultLogoutUrl = 'https://api.appcelerator.com/p/v1/sso-logout',
+	myAppc = 'https://my.appcelerator.com/',
+
+	cachedStatus,
+	cachedMid;
+
+
+/**
+ * Authenticates a user into the Appcelerator Network.
+ * @param {Object} args - Login arguments
+ * @param {String} args.username - The email address to log in as
+ * @param {String} args.password - The password
+ * @param {Function} args.callback(error, result) - The function to call once logged in or on error
+ * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
+ * @param {String} [args.loginUrl] - The URL to authenticate against
+ * @param {String} [args.proxy] - The proxy server to use
+ */
+exports.login = function login(args) {
+	args || (args = {});
+	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
+
+	try {
+		assertSessionFile(args.titaniumHomeDir);
+	} catch (ex) {
+		args.callback(ex);
+		return;
+	}
+
+	cachedStatus = null;
+	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json');
+
+	exports.getMID(args.titaniumHomeDir, function (mid) {
+		// Otherwise we need to re-auth with the server
+		request({
+			uri: args.loginUrl || defaultLoginUrl,
+			method: 'POST',
+			proxy: args.proxy,
+			jar: false, // don't save cookies
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded'
+			},
+			rejectUnauthorized: args.rejectUnauthorized === undefined ? true : !!args.rejectUnauthorized,
+			body: net.urlEncode({
+				un: args.username,
+				pw: args.password,
+				mid: mid
+			})
+		}, function (error, response, body) {
+			try {
+				if (error) {
+					throw new Error(__('Error communicating with the server: %s', error));
+				}
+
+				var res = JSON.parse(body);
+				if (res.success) {
+					var cookie = response.headers['set-cookie'];
+					if (cookie && cookie.length === 1 && cookie[0].match('^PHPSESSID')) {
+						// Create the result
+						var result = {
+							loggedIn: true,
+							cookie: cookie[0],
+							data: {
+								uid: res.uid,
+								guid: res.guid,
+								email: res.email
+							}
+						};
+
+						// Write the data out to the session file
+						if (!fs.existsSync(args.titaniumHomeDir)) {
+							wrench.mkdirSyncRecursive(args.titaniumHomeDir);
+						}
+						fs.writeFileSync(sessionFile, JSON.stringify(result));
+
+						args.callback(null, result);
+					} else {
+						throw new Error(__('Server did not return a session cookie'));
+					}
+				} else if (res.code === 4 || res.code === 5) {
+					throw new Error(__('Invalid username or password. If you have forgotten your password, please visit %s.', myAppc.cyan));
+				} else {
+					throw new Error(__('Invalid server response'));
+				}
+			} catch (ex) {
+				createLoggedOutSessionFile(args.titaniumHomeDir);
+				args.callback(ex);
+			}
+		});
+	});
+};
+
+/**
+ * Logs the user out of the Appcelerator Network.
+ * @param {Object} args - Logout arguments
+ * @param {Function} args.callback(error, result) - The function to call once logged out or on error
+ * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
+ * @param {String} [args.logoutUrl] - The URL to use to end session
+ * @param {String} [args.proxy] - The proxy server to use
+ */
+exports.logout = function logout(args) {
+	args || (args = {});
+	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
+
+	try {
+		assertSessionFile(args.titaniumHomeDir);
+	} catch (ex) {
+		args.callback(ex);
+		return;
+	}
+
+	cachedStatus = null;
+	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json');
+
+	if (!fs.existsSync(sessionFile)) {
+		// Create a default (logged out) session file
+		args.callback(null, mix(createLoggedOutSessionFile(sessionFile), { success: true, alreadyLoggedOut: true }));
+		return;
+	}
+
+	try {
+		var session = JSON.parse(fs.readFileSync(sessionFile));
+		if (session.loggedIn) {
+			request({
+				uri: args.logoutUrl || defaultLogoutUrl,
+				method: 'GET',
+				proxy: args.proxy,
+				headers: {
+					'Cookie': session.cookie
+				},
+				rejectUnauthorized: args.rejectUnauthorized === undefined ? true : !!args.rejectUnauthorized
+			}, function (error, response, body) {
+				var result = createLoggedOutSessionFile(sessionFile);
+				try {
+					if (error) {
+						throw new Error(__('Error communicating with the server: %s', error));
+					}
+
+					var res = JSON.parse(body);
+					if (res.success) {
+						mix(result, { success: true, alreadyLoggedOut: false });
+					} else {
+						throw new Error(__('Error logging out from server: %s', res.reason));
+					}
+
+					args.callback(null, result);
+				} catch (ex) {
+					args.callback(ex, result);
+				}
+			});
+		} else {
+			args.callback(null, mix(session, { success: true, alreadyLoggedOut: true }));
+		}
+	} catch (ex) { // Invalid session file. This should never happen
+		args.callback(ex, mix(createLoggedOutSessionFile(sessionFile), { success: true, alreadyLoggedOut: true }));
+	}
+};
+
+exports.getSessionInfo = function getSessionInfo(args)
+{
+	args || (args = {});
+	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
+
+	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json'),
+		result = {},
+		session;
+
+	if (fs.existsSync(sessionFile)) {
+		try {
+			// Fetch and parse the session data
+			return JSON.parse(fs.readFileSync(sessionFile));
+		}  catch (e) { // Invalid session file. This should never happen
+		}
+	}
+	return {};
+}
+
+/**
+ * Returns whether the user is current logged in.
+ * @param {Object} [args] - Status arguments
+ * @param {String} [args.titaniumHomeDir] - The Titanium home directory where the session files are stored
+ * @returns {Object} An object containing the session status
+ */
+exports.status = function status(args) {
+	if (cachedStatus) return cachedStatus;
+
+	args || (args = {});
+	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
+
+	var sessionFile = path.join(args.titaniumHomeDir, 'auth_session.json'),
+		result = {},
+		session;
+
+	if (fs.existsSync(sessionFile)) {
+		try {
+			// Fetch and parse the session data
+			session = JSON.parse(fs.readFileSync(sessionFile));
+			result = {
+				loggedIn: session.loggedIn,
+				uid: session.data && session.data.uid,
+				guid: session.data && session.data.guid,
+				email: session.data && session.data.email,
+				cookie: session.cookie
+			};
+		} catch (e) { // Invalid session file. This should never happen
+			result = createLoggedOutSessionFile(sessionFile);
+		}
+	} else {
+		result = createLoggedOutSessionFile(sessionFile); // No prior history, create a new logged out file
+	}
+
+	return cachedStatus = result;
+};
+
+exports.getTitaniumHomeDir = function getTitaniumHomeDir(args)
+{
+	args || (args = {});
+	args.titaniumHomeDir = afs.resolvePath(args.titaniumHomeDir || defaultTitaniumHomeDir);
+	try {
+		assertSessionFile(args.titaniumHomeDir);
+	} catch (ex) {
+		args.callback(ex);
+		return null;
+	}
+	return args.titaniumHomeDir;
+
+}
+
+/**
+ * Returns the machine id (mid) or generates a new one based on the computer's
+ * primary network interface's MAC address.
+ * @param {String} titaniumHomeDir - The Titanium home directory where the session files are stored
+ * @param {Function} callback - A callback to fire with the result
+ */
+exports.getMID = function getMID(titaniumHomeDir, callback) {
+	if (cachedMid) {
+		callback(cachedMid);
+	} else {
+		var midFile = path.join(titaniumHomeDir, 'mid.json');
+		if (fs.existsSync(midFile)) {
+			try {
+				cachedMid = JSON.parse(fs.readFileSync(midFile)).mid;
+				if (cachedMid) {
+					callback(cachedMid);
+					return;
+				}
+			} catch (e) {} // File/MID entry doesn't exist, so we need to recreate it
+		}
+
+		// If it got here, we couldn't fetch the previous MID
+		net.interfaces(function (ifaces) {
+			// Find the MAC address of the local ethernet card
+			var macAddress,
+				names = Object.keys(ifaces).sort(),
+				i, j;
+
+			for (i = 0; i < names.length; i++) {
+				j = ifaces[names[i]];
+				if (j.macAddress) {
+					macAddress = j.macAddress;
+					if (/^eth|en|Local Area Connection/.test(j)) {
+						break;
+					}
+				}
+			}
+
+			macAddress || (macAddress = uuid.v4());
+
+			// Create the MID, using the MAC address as a seed
+			cachedMid = crypto.createHash('md5').update(macAddress).digest('hex');
+
+			// Write the MID to its file
+			if (!fs.existsSync(titaniumHomeDir)) {
+				wrench.mkdirSyncRecursive(titaniumHomeDir);
+			}
+			fs.writeFileSync(midFile, JSON.stringify({ mid: cachedMid }));
+
+			callback(cachedMid);
+		});
+	}
+};
+
+/**
+ * Asserts the session file exists that the file is writable or the session file
+ * does not exist and the Titanium home directory is writable.
+ * @param {String} titaniumHomeDir - The Titanium home directory where the session files are stored
+ * @throws {AppcException} If session file or Titanium home directory is not writable
+ * @private
+ */
+function assertSessionFile(titaniumHomeDir) {
+	var sessionFile = path.join(titaniumHomeDir, 'auth_session.json');
+
+	// check that the file is writable
+	if (fs.existsSync(sessionFile)) {
+		if (!afs.isFileWritable(sessionFile)) {
+			throw new AppcException(__('Session file "%s" is not writable', sessionFile), __('Please ensure the Titanium CLI has access to modify this file.'));
+		}
+
+	// check that the .titanium folder is writable
+	} else if (fs.existsSync(titaniumHomeDir) && !afs.isDirWritable(titaniumHomeDir)) {
+		throw new AppcException(__('Directory "%s" is not writable', titaniumHomeDir), __('Please ensure the Titanium CLI has access to this directory.'));
+	}
+}
+
+/**
+ * Creates the session file with a logged out status.
+ * @param {String} sessionFile - Path to the session file.
+ * @returns {Object} An object contain the logged out session status
+ * @private
+ */
+function createLoggedOutSessionFile(sessionFile) {
+	var result = { loggedIn: false },
+		titaniumHomeDir = path.dirname(sessionFile),
+		session, loggedIn;
+	try {
+		session = JSON.parse(fs.readFileSync(sessionFile));
+		loggedIn = session.loggedIn;
+		if (!fs.existsSync(titaniumHomeDir)) {
+			wrench.mkdirSyncRecursive(titaniumHomeDir);
+		}
+		fs.writeFileSync(sessionFile, JSON.stringify(result));
+	} catch (e) {
+		result.loggedIn = loggedIn;
+		result.error = e;
+	}
+	return result;
+}


### PR DESCRIPTION
- With the introduction of On-Demand model integration changes, CLI should login into Appclerator Platform (360) by default, and then based on the API server url returned by the 360 login, we should do a login into API server.
- Considering that the 360 is the priority login, the auth APIs are modified to login into 360 now and the original API server details are forked into a different js file (authapiserver.js).
- When the user attempts to login, it logs into 360 server, grabs the API server details from the login payload, and then, attempt to login into API server and then, it attempts to retrieve the organization details and write the details into appc_session.json in home directory.


