### PR TITLE
Detect certificates that use Apple's new 'iOS xxx' naming convention

### DIFF
--- a/lib/ios.js
+++ b/lib/ios.js
@@ -148,7 +148,7 @@ exports.detect = function detect(finished, opts) {
 					result.error = new exception('Failed during "security dump-keychain"', err.join('').split('\n'));
 				} else {
 					out.join('').split('keychain: ').forEach(function (line) {
-						var m = line.match(/"alis"<blob>=[^"]*"(?:(?:iPhone (Developer|Distribution)\: (.*))|(Apple Worldwide Developer Relations Certification Authority))"/);
+						var m = line.match(/"alis"<blob>=[^"]*"(?:(?:(?:iOS|iPhone) (Developer|Development|Distribution)\: (.*))|(Apple Worldwide Developer Relations Certification Authority))"/);
 						if (m) {
 							if (m[3]) {
 								result.wwdr = true;
@@ -156,6 +156,9 @@ exports.detect = function detect(finished, opts) {
 								var type = m[1].toLowerCase(),
 									name = enc.decodeOctalUTF8(m[2]),
 									keychain = line.match(/^\s*"(.+)"/);
+								if (type == 'development') {
+									type = 'developer';
+								}
 
 								if (!devNames[name] && !distNames[name]) {
 									if (keychain) {


### PR DESCRIPTION
As discussed in http://developer.appcelerator.com/question/178922/unable-to-find-any-valid-ios-developer-certificates, recent certificates issued by Apple use the naming pattern "iOS Development: ..." and "iOS Distribution: ..."