### PR TITLE
Handle corrupt manifests without moduleid

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -479,7 +479,7 @@ function detectModules(params) {
 										}
 									}
 
-									params.logger && params.logger.debug(__('Detected %s module: %s %s @ %s', platform, mod[ver].manifest.moduleid.cyan, ver, mod[ver].modulePath));
+									params.logger && params.logger.debug(__('Detected %s module: %s %s @ %s', platform, (mod[ver].manifest.moduleid || '').cyan, ver, mod[ver].modulePath));
 								}
 							}
 						});


### PR DESCRIPTION
Fixing https://community.appcelerator.com/topic/3013/problem-to-run-mobile-app/2
