### PR TITLE
Check for jdk undefined while looping through jdks array

### DIFF
--- a/lib/jdk.js
+++ b/lib/jdk.js
@@ -227,11 +227,13 @@ exports.detect = function detect(config, opts, finished) {
 		}), function (err, jdks) {
 			if (jdks.length) {
 				jdks.forEach(function (jdk) {
-					results.jdks[jdk.version + '_' + jdk.build] = jdk;
+					if(typeof jdk !== "undefined"){
+						results.jdks[jdk.version + '_' + jdk.build] = jdk;
 
-					// only add the first jdk as it's probably the JAVA_HOME based one
-					if (results.version === null) {
-						mix(results, jdk);
+						// only add the first jdk as it's probably the JAVA_HOME based one
+						if (results.version === null) {
+							mix(results, jdk);
+						}
 					}
 				});
 			} else {


### PR DESCRIPTION
On my machine, for some reason there was an undefined value in the jdks array. The only way I could get everything to run locally for me was to add a check for undefined.
