### PR TITLE
Fix error when old JDKs are still in path

### DIFF
--- a/lib/jdk.js
+++ b/lib/jdk.js
@@ -225,6 +225,9 @@ exports.detect = function detect(config, opts, finished) {
 				});
 			};
 		}), function (err, jdks) {
+			// Filter for only valid JDKs
+			jdks = jdks.filter(function (jdk) { return jdk; });
+			
 			if (jdks.length) {
 				jdks.forEach(function (jdk) {
 					results.jdks[jdk.version + '_' + jdk.build] = jdk;


### PR DESCRIPTION
When an old JDK is listed, but missing from the actual file system, the `jdk` variable in the `forEach` loop will be undefined, causing the error "cannot read property 'version' of undefined" to be thrown. This fix filters out invalid JDKs before they even get to the loop, and still allows the `length` check to do its thing if after the filtering there are no valid JDKs.