### PR TITLE
[TIMOB-25429] Add JDK 9 detection

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -88,14 +88,25 @@ exports.detect = function detect(finished, sdkPath, ndkPath) {
 
 		function (next) {
 			exec('javac -version', function (err, stdout, stderr) {
-				if (!err) {
-					var m = stderr.match(/javac (.+)_(.+)/);
-					if (m) {
-						result.java.version = m[1];
-						result.java.build = m[2];
+				if (err) {
+					next();
+				}
+				var re = /^javac (.+?)(?:_(.+))?$/
+				var m = stderr.trim().match(re) || stdout.trim().match(re);;
+				if (m) {
+					result.java.version = m[1];
+					result.java.build = m[2];
+					if (!result.java.build) {
+						exec('java -version', function(err, stdout, stderr) {
+							var m = stderr.trim().match(/\(build .+?\+(\d+)\)/);
+							result.java.build = m && m[1];
+							next();
+						});
+					} else {
+						next();
 					}
 				}
-				next();
+			
 			});
 		},
 

--- a/lib/android.js
+++ b/lib/android.js
@@ -89,24 +89,24 @@ exports.detect = function detect(finished, sdkPath, ndkPath) {
 		function (next) {
 			exec('javac -version', function (err, stdout, stderr) {
 				if (err) {
-					next();
+					return next();
 				}
 				var re = /^javac (.+?)(?:_(.+))?$/
 				var m = stderr.trim().match(re) || stdout.trim().match(re);;
-				if (m) {
-					result.java.version = m[1];
-					result.java.build = m[2];
-					if (!result.java.build) {
-						exec('java -version', function(err, stdout, stderr) {
-							var m = stderr.trim().match(/\(build .+?\+(\d+)\)/);
-							result.java.build = m && m[1];
-							next();
-						});
-					} else {
-						next();
-					}
+				if (!m) {
+					return next();
 				}
-			
+				result.java.version = m[1];
+				result.java.build = m[2];
+				if (!result.java.build) {
+					exec('java -version', function(err, stdout, stderr) {
+						var m = stderr.trim().match(/\(build .+?\+(\d+)\)/);
+						result.java.build = m && m[1];
+						next();
+					});
+				} else {
+					next();
+				}
 			});
 		},
 

--- a/lib/jdk.js
+++ b/lib/jdk.js
@@ -61,7 +61,7 @@ exports.detect = function detect(config, opts, finished) {
 		};
 
 	function isJDK(dir) {
-		if (fs.existsSync(path.join(dir, 'bin', 'javac' + exe)) && fs.existsSync(path.join(dir, 'lib', 'dt.jar'))) {
+		if (fs.existsSync(path.join(dir, 'bin', 'javac' + exe))) {
 			// try to find the jvm lib
 			var libjvmLocations = [];
 
@@ -71,7 +71,8 @@ exports.detect = function detect(config, opts, finished) {
 						'lib/amd64/client/libjvm.so',
 						'lib/amd64/server/libjvm.so',
 						'jre/lib/amd64/client/libjvm.so',
-						'jre/lib/amd64/server/libjvm.so'
+						'jre/lib/amd64/server/libjvm.so',
+						'lib/server/libjvm.so'
 					];
 				} else {
 					libjvmLocations = [
@@ -84,12 +85,14 @@ exports.detect = function detect(config, opts, finished) {
 			} else if (process.platform === 'darwin') {
 				libjvmLocations = [
 					'jre/lib/server/libjvm.dylib',
-					'../Libraries/libjvm.dylib'
+					'../Libraries/libjvm.dylib',
+					'lib/server/libjvm.dylib'
 				];
 			} else if (process.platform === 'win32') {
 				libjvmLocations = [
 					'jre/bin/server/jvm.dll',
-					'jre/bin/client/jvm.dll'
+					'jre/bin/client/jvm.dll',
+					'bin/server/jvm.dll'
 				];
 			}
 
@@ -198,13 +201,27 @@ exports.detect = function detect(config, opts, finished) {
 					return next();
 				}
 
-				function finalize(str, arch) {
-					var m = str !== null && str.match(/javac (.+)_(.+)/);
+				function finalize(stderr, stdout, arch) {
+					var re = /^javac (.+?)(?:_(.+))?$/;
+					var m = (stderr && stderr.trim().match(re)) || (stdout && stdout.trim().match(re));
 					if (m) {
 						jdkInfo.version = m[1];
 						jdkInfo.build = m[2];
 						jdkInfo.architecture = arch;
-						next(null, jdkInfo);
+						// JDK 9 doesn't return the build number in javac like previous JDKs.
+						// We must spawn java -version to obtain it
+						// JDK 9: javac 9
+						// JDK <= 1.8: javac 1.7.0_80
+						if (!jdkInfo.build) {
+							run(jdkInfo.executables.java, [ '-version' ], function(err, stdout, stderr) {
+								var m = stderr.trim().match(/\(build .+?\+(\d+)\)/);
+								jdkInfo.build = m && m[1];
+								next(null, jdkInfo);
+							});
+						} else {
+							next(null, jdkInfo);
+
+						}
 					} else {
 						next();
 					}
@@ -215,12 +232,14 @@ exports.detect = function detect(config, opts, finished) {
 				run(jdkInfo.executables.javac, ['-version', '-d64'], function (code, stdout, stderr) {
 					if (!code) {
 						// 64-bit version
-						return finalize(stderr, '64bit');
+						return finalize(stderr, stdout, '64bit');
 					}
 
 					// try the 32-bit version
 					run(jdkInfo.executables.javac, '-version', function (code, stdout, stderr) {
-						finalize(code ? null : stderr, '32bit');
+						if (!code) {
+							finalize(stderr, stdout, '32bit');
+						}
 					});
 				});
 			};

--- a/lib/jdk.js
+++ b/lib/jdk.js
@@ -220,7 +220,6 @@ exports.detect = function detect(config, opts, finished) {
 							});
 						} else {
 							next(null, jdkInfo);
-
 						}
 					} else {
 						next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,895 @@
+{
+	"name": "node-appc",
+	"version": "0.2.43",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"adm-zip": {
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+			"integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			}
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+		},
+		"async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
+			"integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"colors": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"requires": {
+				"boom": "2.10.1"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"diff": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"fs-extra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
+			"integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"growl": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"dev": true
+		},
+		"har-schema": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+		},
+		"har-validator": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"requires": {
+				"ajv": "4.11.8",
+				"har-schema": "1.0.5"
+			}
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"dev": true
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+			"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"mocha": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+			"integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.11.0",
+				"debug": "3.1.0",
+				"diff": "3.3.1",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.3",
+				"he": "1.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "4.4.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+					"dev": true
+				}
+			}
+		},
+		"mocha-jenkins-reporter": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.3.7.tgz",
+			"integrity": "sha1-jIbzvW4dVvwtSArgOCm9eCfUBSc=",
+			"dev": true,
+			"requires": {
+				"diff": "1.0.7",
+				"mkdirp": "0.5.1",
+				"mocha": "5.0.1",
+				"xml": "1.0.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+					"integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"requires": {
+				"minimist": "0.0.10",
+				"wordwrap": "0.0.3"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"performance-now": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"request": {
+			"version": "2.81.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "4.2.1",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "0.2.0",
+				"qs": "6.4.0",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.0.1"
+			}
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"semver": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+		},
+		"should": {
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
+			"integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
+			"dev": true,
+			"requires": {
+				"should-equal": "1.0.1",
+				"should-format": "3.0.3",
+				"should-type": "1.4.0",
+				"should-type-adaptors": "1.1.0",
+				"should-util": "1.0.0"
+			}
+		},
+		"should-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+			"integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
+			"dev": true,
+			"requires": {
+				"should-type": "1.4.0"
+			}
+		},
+		"should-format": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+			"dev": true,
+			"requires": {
+				"should-type": "1.4.0",
+				"should-type-adaptors": "1.1.0"
+			}
+		},
+		"should-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+			"integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+			"dev": true
+		},
+		"should-type-adaptors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+			"dev": true,
+			"requires": {
+				"should-type": "1.4.0",
+				"should-util": "1.0.0"
+			}
+		},
+		"should-util": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+			"integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+			"dev": true
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"sprintf": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+			"integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8="
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"supports-color": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+			"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+			"dev": true,
+			"requires": {
+				"has-flag": "2.0.0"
+			}
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"uglify-js": {
+			"version": "2.8.21",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.21.tgz",
+			"integrity": "sha1-FzP2aa5vgvyQx7JewPXHg+43UxQ=",
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"optional": true
+		},
+		"uuid": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+			"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"xml": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+			"integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+			"dev": true
+		},
+		"xmldom": {
+			"version": "0.1.22",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
+			"integrity": "sha1-EN5OXpZJgfA8jMcvrcCNFLbDqiY="
+		},
+		"yargs": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+			"requires": {
+				"camelcase": "1.2.1",
+				"cliui": "2.1.0",
+				"decamelize": "1.2.0",
+				"window-size": "0.1.0"
+			}
+		}
+	}
+}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-25429

Tested across OSX, Windows and Ubuntu.

Attempted to add tests but due to the way that the jdk functionality spawns executables it doesn't seem easy to set up mocking similar to how we test in jdklib, although I might be able to mock out some of the subprocess functions to return the mocks, @cb1kenobi any guidance you might have is appreciated.