### PR TITLE
fix(timodule): group modules by id, not name

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -24,7 +24,7 @@ const zip = require('./zip');
 const platformAliases = {
 	// add additional aliases here for new platforms
 	ipad: 'ios',
-	iphone: 'ios'
+	iphone: 'ios',
 };
 
 let moduleCache = {};
@@ -780,10 +780,7 @@ function convertArrayOfModulesToHierarchy(modules) {
 	const result = {};
 	modules && modules.forEach(m => {
 		const platform = m.platform[0];
-		// FIXME: For whatever reason this code grouped by module name and not id!
-		// This seems wrong to me, as we should really be combining entries based on the id, not the name
-		// But for now, fixing this to group by moduleid breaks tests which assume the name is used (and some questionable test fixture data)
-		const name = m.manifest.name;
+		const name = m.manifest.moduleid;
 		const version = m.version;
 		result[platform] = (result[platform] || {});
 		result[platform][name] = (result[platform][name] || {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-appc",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "appcelerator"
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "npmjs@appcelerator.com"

--- a/test/resources/timodule4/modules/iphone/ti.map/3.1.0/manifest
+++ b/test/resources/timodule4/modules/iphone/ti.map/3.1.0/manifest
@@ -1,0 +1,18 @@
+#
+# this is your module manifest and used by Titanium
+# during compilation, packaging, distribution, etc.
+#
+version: 3.1.0
+apiversion: 2
+architectures: armv7 arm64 i386 x86_64
+description: External version of Map module
+author: Jeff Haynie, Jon Alter, Pedro Enrique, Hans Knöchel, Vijay Singh
+license: Apache Public License v2
+copyright: Copyright (c) 2013-present by Axway Appcelerator
+
+# these should not be edited
+name: map
+moduleid: ti.map
+guid: fee93b77-8eb3-418c-8f04-013664c4af83
+platform: iphone
+minsdk: 6.2.2.GA

--- a/test/test-timodule.js
+++ b/test/test-timodule.js
@@ -39,6 +39,8 @@ function MockLogger() {
 }
 
 describe('timodule', function () {
+	this.timeout(1000);
+
 	it('namespace exists', function () {
 		appc.should.have.property('timodule');
 		appc.timodule.should.be.an.Object;
@@ -84,20 +86,24 @@ describe('timodule', function () {
 			appc.timodule.scopedDetect({
 				testResources: path.join(testResourcesDir, 'modules')
 			}, new MockConfig(), logger, function (result) {
-				fs.existsSync(goodZipFile) && fs.unlinkSync(goodZipFile);
-				fs.existsSync(badZipFile) && fs.unlinkSync(badZipFile);
+				try {
+					fs.existsSync(goodZipFile) && fs.unlinkSync(goodZipFile);
+					fs.existsSync(badZipFile) && fs.unlinkSync(badZipFile);
 
-				logger.buffer.stripColors.should.containEql('Installing module: dummy-ios-1.2.3.zip');
-				logger.buffer.stripColors.should.containEql('Installing module: badzip-ios-1.0.0.zip');
-				logger.buffer.stripColors.should.containEql('Failed to unzip module "' + badZipFile + '"');
+					logger.buffer.stripColors.should.containEql('Installing module: dummy-ios-1.2.3.zip');
+					logger.buffer.stripColors.should.containEql('Installing module: badzip-ios-1.0.0.zip');
+					logger.buffer.stripColors.should.containEql('Failed to unzip module "' + badZipFile + '"');
 
-				result.should.be.an.Object;
-				result.should.have.property('testResources');
-				result.testResources.should.have.property('ios');
-				result.testResources.ios.should.be.an.Object;
-				result.testResources.ios.should.have.property('dummy');
+					result.should.be.an.Object;
+					result.should.have.property('testResources');
+					result.testResources.should.have.property('ios');
+					result.testResources.ios.should.be.an.Object;
+					result.testResources.ios.should.have.property('ti.dummy');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			});
 		});
 
@@ -108,23 +114,27 @@ describe('timodule', function () {
 			appc.timodule.scopedDetect({
 				testResources: path.join(testResourcesDir, 'modules')
 			}, new MockConfig(), logger, function (result) {
-				logger.buffer.stripColors.should.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
-				logger.buffer.stripColors.should.containEql('Detected ios module: ti.dummy 1.2.3 @ ' + dummyModuleDir);
-				logger.buffer.stripColors.should.containEql('Detected ios module: ti.toonew 1.0 @ ' + toonewModuleDir);
-				logger.buffer.stripColors.should.containEql('Detected ios module: ti.ambiguous 1.0 @ ' + ambiguousModuleDir);
-				logger.buffer.stripColors.should.containEql('Detected commonjs module: ti.ambiguous 1.0 @ ' + ambiguousCommonJSModuleDir);
+				try {
+					logger.buffer.stripColors.should.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
+					logger.buffer.stripColors.should.containEql('Detected ios module: ti.dummy 1.2.3 @ ' + dummyModuleDir);
+					logger.buffer.stripColors.should.containEql('Detected ios module: ti.toonew 1.0 @ ' + toonewModuleDir);
+					logger.buffer.stripColors.should.containEql('Detected ios module: ti.ambiguous 1.0 @ ' + ambiguousModuleDir);
+					logger.buffer.stripColors.should.containEql('Detected commonjs module: ti.ambiguous 1.0 @ ' + ambiguousCommonJSModuleDir);
 
-				result.should.be.an.Object;
-				result.should.have.property('testResources');
-				result.testResources.should.have.property('ios');
-				result.testResources.ios.should.be.an.Object;
-				result.testResources.ios.should.have.property('dummy');
-				result.testResources.ios.should.have.property('toonew');
-				result.testResources.ios.should.have.property('ambiguous');
-				result.testResources.commonjs.should.be.an.Object;
-				result.testResources.commonjs.should.have.property('ambiguous');
+					result.should.be.an.Object;
+					result.should.have.property('testResources');
+					result.testResources.should.have.property('ios');
+					result.testResources.ios.should.be.an.Object;
+					result.testResources.ios.should.have.property('ti.dummy');
+					result.testResources.ios.should.have.property('ti.toonew');
+					result.testResources.ios.should.have.property('ti.ambiguous');
+					result.testResources.commonjs.should.be.an.Object;
+					result.testResources.commonjs.should.have.property('ti.ambiguous');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
@@ -135,8 +145,12 @@ describe('timodule', function () {
 			appc.timodule.scopedDetect({
 				testResources: path.join(testResourcesDir, 'modules')
 			}, new MockConfig(), logger, function () {
-				logger.buffer.stripColors.should.not.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
-				done();
+				try {
+					logger.buffer.stripColors.should.not.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
+					done();
+				} catch (e) {
+					done(e);
+				}
 			});
 		});
 	});
@@ -148,39 +162,7 @@ describe('timodule', function () {
 
 			// we test for dupe search paths, but only one should be searched
 			appc.timodule.detect([ dir, dir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
-				logger.buffer.stripColors.should.containEql('Detected ios module: ti.dummy 1.2.3 @ ' + dummyModuleDir);
-				logger.buffer.stripColors.should.containEql('Detected ios module: ti.toonew 1.0 @ ' + toonewModuleDir);
-				logger.buffer.stripColors.should.containEql('Detected ios module: ti.ambiguous 1.0 @ ' + ambiguousModuleDir);
-				logger.buffer.stripColors.should.containEql('Detected commonjs module: ti.ambiguous 1.0 @ ' + ambiguousCommonJSModuleDir);
-
-				var dupeSearch = logger.buffer.stripColors.split('Detected ios module: ti.dummy 1.2.3 @').length - 1;
-				assert(dupeSearch === 1, 'Path searched ' + dupeSearch + ' times instead of once');
-
-				result.should.be.an.Object;
-				result.should.have.property('global');
-				result.should.have.property('project');
-				result.project.should.have.property('ios');
-				result.project.ios.should.be.an.Object;
-				result.project.ios.should.have.property('dummy');
-				result.project.ios.should.have.property('toonew');
-				result.project.ios.should.have.property('ambiguous');
-				result.project.should.have.property('commonjs');
-				result.project.commonjs.should.have.property('ambiguous');
-				done();
-			}, true);
-		});
-
-		it('should find the test modules with params object', function (done) {
-			const logger = new MockLogger(),
-				dir = path.join(__dirname, 'resources', 'timodule');
-
-			// we test for dupe search paths, but only one should be searched
-			appc.timodule.detect({
-				bypassCache: true,
-				searchPaths: [ dir, dir ],
-				logger: logger,
-				callback: function (result) {
+				try {
 					logger.buffer.stripColors.should.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
 					logger.buffer.stripColors.should.containEql('Detected ios module: ti.dummy 1.2.3 @ ' + dummyModuleDir);
 					logger.buffer.stripColors.should.containEql('Detected ios module: ti.toonew 1.0 @ ' + toonewModuleDir);
@@ -195,12 +177,52 @@ describe('timodule', function () {
 					result.should.have.property('project');
 					result.project.should.have.property('ios');
 					result.project.ios.should.be.an.Object;
-					result.project.ios.should.have.property('dummy');
-					result.project.ios.should.have.property('toonew');
-					result.project.ios.should.have.property('ambiguous');
+					result.project.ios.should.have.property('ti.dummy');
+					result.project.ios.should.have.property('ti.toonew');
+					result.project.ios.should.have.property('ti.ambiguous');
 					result.project.should.have.property('commonjs');
-					result.project.commonjs.should.have.property('ambiguous');
+					result.project.commonjs.should.have.property('ti.ambiguous');
 					done();
+				} catch (e) {
+					done(e);
+				}
+			}, true);
+		});
+
+		it('should find the test modules with params object', function (done) {
+			const logger = new MockLogger(),
+				dir = path.join(__dirname, 'resources', 'timodule');
+
+			// we test for dupe search paths, but only one should be searched
+			appc.timodule.detect({
+				bypassCache: true,
+				searchPaths: [ dir, dir ],
+				logger: logger,
+				callback: function (result) {
+					try {
+						logger.buffer.stripColors.should.containEql('Detecting modules in ' + path.join(testResourcesDir, 'modules'));
+						logger.buffer.stripColors.should.containEql('Detected ios module: ti.dummy 1.2.3 @ ' + dummyModuleDir);
+						logger.buffer.stripColors.should.containEql('Detected ios module: ti.toonew 1.0 @ ' + toonewModuleDir);
+						logger.buffer.stripColors.should.containEql('Detected ios module: ti.ambiguous 1.0 @ ' + ambiguousModuleDir);
+						logger.buffer.stripColors.should.containEql('Detected commonjs module: ti.ambiguous 1.0 @ ' + ambiguousCommonJSModuleDir);
+
+						var dupeSearch = logger.buffer.stripColors.split('Detected ios module: ti.dummy 1.2.3 @').length - 1;
+						assert(dupeSearch === 1, 'Path searched ' + dupeSearch + ' times instead of once');
+
+						result.should.be.an.Object;
+						result.should.have.property('global');
+						result.should.have.property('project');
+						result.project.should.have.property('ios');
+						result.project.ios.should.be.an.Object;
+						result.project.ios.should.have.property('ti.dummy');
+						result.project.ios.should.have.property('ti.toonew');
+						result.project.ios.should.have.property('ti.ambiguous');
+						result.project.should.have.property('commonjs');
+						result.project.commonjs.should.have.property('ti.ambiguous');
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -214,8 +236,8 @@ describe('timodule', function () {
 					result.should.have.property('project');
 					result.project.should.have.property('ios');
 					result.project.ios.should.be.an.Object;
-					result.project.ios.should.have.property('Native Module');
-					const nativeModule = result.project.ios['Native Module']['2.0.1'];
+					result.project.ios.should.have.property('native-module');
+					const nativeModule = result.project.ios['native-module']['2.0.1'];
 					nativeModule.id.should.eql('native-module');
 					nativeModule.modulePath.should.eql(path.join(__dirname, 'resources/npm-native-module/node_modules/native-module'));
 					nativeModule.platform.should.eql([ 'ios' ]);
@@ -244,14 +266,14 @@ describe('timodule', function () {
 					result.project.should.have.property('ios');
 					result.project.ios.should.be.an.Object;
 					// has the "legacy" modules
-					result.project.ios.should.have.property('dummy');
-					result.project.ios.should.have.property('toonew');
-					result.project.ios.should.have.property('ambiguous');
+					result.project.ios.should.have.property('ti.dummy');
+					result.project.ios.should.have.property('ti.toonew');
+					result.project.ios.should.have.property('ti.ambiguous');
 					result.project.should.have.property('commonjs');
-					result.project.commonjs.should.have.property('ambiguous');
+					result.project.commonjs.should.have.property('ti.ambiguous');
 					// has the native module supplied via node_modules
-					result.project.ios.should.have.property('Native Module');
-					const nativeModule = result.project.ios['Native Module']['2.0.1'];
+					result.project.ios.should.have.property('native-module');
+					const nativeModule = result.project.ios['native-module']['2.0.1'];
 					nativeModule.id.should.eql('native-module');
 					nativeModule.modulePath.should.eql(path.join(__dirname, 'resources/npm-native-module/node_modules/native-module'));
 					nativeModule.platform.should.eql([ 'ios' ]);
@@ -274,13 +296,17 @@ describe('timodule', function () {
 		it('should return immediately if no modules with individual params', function (done) {
 			const logger = new MockLogger();
 			appc.timodule.find([], null, null, null, null, logger, function (result) {
-				result.should.eql({
-					found: [],
-					missing: [],
-					incompatible: [],
-					conflict: []
-				});
-				done();
+				try {
+					result.should.eql({
+						found: [],
+						missing: [],
+						incompatible: [],
+						conflict: []
+					});
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
@@ -294,13 +320,17 @@ describe('timodule', function () {
 				searchPaths: null,
 				logger: logger,
 				callback: function (result) {
-					result.should.eql({
-						found: [],
-						missing: [],
-						incompatible: [],
-						conflict: []
-					});
-					done();
+					try {
+						result.should.eql({
+							found: [],
+							missing: [],
+							incompatible: [],
+							conflict: []
+						});
+						done();
+					} catch (e) {
+						done(e);
+					}
 				},
 				bypassCache: true
 			});
@@ -309,26 +339,30 @@ describe('timodule', function () {
 		it('should find "dummy" module using only the id with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy' }
+				{ id: 'ti.dummy' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
+					);
 
-				var found = false;
-				for (var i = 0; !found && i < result.found.length; i++) {
-					found = (result.found[i].id === 'dummy');
+					var found = false;
+					for (var i = 0; !found && i < result.found.length; i++) {
+						found = (result.found[i].id === 'ti.dummy');
+					}
+					assert(found, '"ti.dummy" module not marked as found');
+
+					done();
+				} catch (e) {
+					done(e);
 				}
-				assert(found, '"dummy" module not marked as found');
-
-				done();
 			}, true);
 		});
 
 		it('should find "dummy" module using only the id with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy' } ],
+				modules: [ { id: 'ti.dummy' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -336,17 +370,21 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
+						);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						found = (result.found[i].id === 'dummy');
+						var found = false;
+						for (var i = 0; !found && i < result.found.length; i++) {
+							found = (result.found[i].id === 'ti.dummy');
+						}
+						assert(found, '"ti.dummy" module not marked as found');
+
+						done();
+					} catch (e) {
+						done(e);
 					}
-					assert(found, '"dummy" module not marked as found');
-
-					done();
 				}
 			});
 		});
@@ -354,28 +392,32 @@ describe('timodule', function () {
 		it('should find "dummy" module with matching version with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy', version: '1.2.3' }
+				{ id: 'ti.dummy', version: '1.2.3' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
+					);
 
-				var found = false;
-				for (var i = 0; !found && i < result.found.length; i++) {
-					if (result.found[i].id === 'dummy') {
-						found = true;
+					var found = false;
+					for (var i = 0; !found && i < result.found.length; i++) {
+						if (result.found[i].id === 'ti.dummy') {
+							found = true;
+						}
 					}
-				}
-				assert(found, '"dummy" module not marked as found');
+					assert(found, '"ti.dummy" module not marked as found');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should find "dummy" module with matching version with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy', version: '1.2.3' } ],
+				modules: [ { id: 'ti.dummy', version: '1.2.3' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -383,19 +425,23 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
+						);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'dummy') {
-							found = true;
+						var found = false;
+						for (var i = 0; !found && i < result.found.length; i++) {
+							if (result.found[i].id === 'ti.dummy') {
+								found = true;
+							}
 						}
-					}
-					assert(found, '"dummy" module not marked as found');
+						assert(found, '"ti.dummy" module not marked as found');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -403,26 +449,30 @@ describe('timodule', function () {
 		it('should not find "dummy" module with wrong version with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy', version: '3.2.1' }
+				{ id: 'ti.dummy', version: '3.2.1' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Could not find a valid Titanium module id=dummy version=3.2.1 platform=ios,commonjs deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Could not find a valid Titanium module id=ti.dummy version=3.2.1 platform=ios,commonjs deploy-type=development'
+					);
 
-				var found = false;
-				for (var i = 0; !found && i < result.missing.length; i++) {
-					found = result.missing[i].id === 'dummy';
+					var found = false;
+					for (var i = 0; !found && i < result.missing.length; i++) {
+						found = result.missing[i].id === 'ti.dummy';
+					}
+					assert(found, '"ti.dummy" module not marked as missing');
+
+					done();
+				} catch (e) {
+					done(e);
 				}
-				assert(found, '"dummy" module not marked as missing');
-
-				done();
 			}, true);
 		});
 
 		it('should not find "dummy" module with wrong version with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy', version: '3.2.1' } ],
+				modules: [ { id: 'ti.dummy', version: '3.2.1' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -430,17 +480,21 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Could not find a valid Titanium module id=dummy version=3.2.1 platform=ios,commonjs deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Could not find a valid Titanium module id=ti.dummy version=3.2.1 platform=ios,commonjs deploy-type=development'
+						);
 
-					var found = false;
-					for (var i = 0; !found && i < result.missing.length; i++) {
-						found = result.missing[i].id === 'dummy';
+						var found = false;
+						for (var i = 0; !found && i < result.missing.length; i++) {
+							found = result.missing[i].id === 'ti.dummy';
+						}
+						assert(found, '"ti.dummy" module not marked as missing');
+
+						done();
+					} catch (e) {
+						done(e);
 					}
-					assert(found, '"dummy" module not marked as missing');
-
-					done();
 				}
 			});
 		});
@@ -448,28 +502,32 @@ describe('timodule', function () {
 		it('should find "dummy" module with matching deploy type with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy', deployType: 'test,production' }
+				{ id: 'ti.dummy', deployType: 'test,production' }
 			], [ 'ios', 'iphone' ], 'production', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=test,production'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=test,production'
+					);
 
-				var found = false;
-				for (var i = 0; !found && i < result.found.length; i++) {
-					if (result.found[i].id === 'dummy') {
-						found = true;
+					var found = false;
+					for (var i = 0; !found && i < result.found.length; i++) {
+						if (result.found[i].id === 'ti.dummy') {
+							found = true;
+						}
 					}
-				}
-				assert(found, '"dummy" module not marked as found');
+					assert(found, '"ti.dummy" module not marked as found');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should find "dummy" module with matching deploy type with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy', deployType: 'test,production' } ],
+				modules: [ { id: 'ti.dummy', deployType: 'test,production' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'production',
 				sdkVersion: '3.2.0',
@@ -477,19 +535,23 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=test,production'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=test,production'
+						);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'dummy') {
-							found = true;
+						var found = false;
+						for (var i = 0; !found && i < result.found.length; i++) {
+							if (result.found[i].id === 'ti.dummy') {
+								found = true;
+							}
 						}
-					}
-					assert(found, '"dummy" module not marked as found');
+						assert(found, '"ti.dummy" module not marked as found');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -497,28 +559,32 @@ describe('timodule', function () {
 		it('should ignore "dummy" module with non-matching deploy type with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy', deployType: 'test,production' }
+				{ id: 'ti.dummy', deployType: 'test,production' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				var found = false;
-				for (let i = 0; !found && i < result.found.length; i++) {
-					found = result.found[i].id === 'dummy';
-				}
-				assert(!found, '"dummy" module was marked as found, should have been ignored');
+				try {
+					var found = false;
+					for (let i = 0; !found && i < result.found.length; i++) {
+						found = result.found[i].id === 'ti.dummy';
+					}
+					assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-				found = false;
-				for (let i = 0; !found && i < result.missing.length; i++) {
-					found = result.missing[i].id === 'dummy';
-				}
-				assert(!found, '"dummy" module was marked as missing, should have been ignored');
+					found = false;
+					for (let i = 0; !found && i < result.missing.length; i++) {
+						found = result.missing[i].id === 'ti.dummy';
+					}
+					assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should ignore "dummy" module with non-matching deploy type with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy', deployType: 'test,production' } ],
+				modules: [ { id: 'ti.dummy', deployType: 'test,production' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -526,19 +592,23 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					var found = false;
-					for (let i = 0; !found && i < result.found.length; i++) {
-						found = result.found[i].id === 'dummy';
-					}
-					assert(!found, '"dummy" module was marked as found, should have been ignored');
+					try {
+						var found = false;
+						for (let i = 0; !found && i < result.found.length; i++) {
+							found = result.found[i].id === 'ti.dummy';
+						}
+						assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-					found = false;
-					for (let i = 0; !found && i < result.missing.length; i++) {
-						found = result.missing[i].id === 'dummy';
-					}
-					assert(!found, '"dummy" module was marked as missing, should have been ignored');
+						found = false;
+						for (let i = 0; !found && i < result.missing.length; i++) {
+							found = result.missing[i].id === 'ti.dummy';
+						}
+						assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -546,28 +616,32 @@ describe('timodule', function () {
 		it('should find "dummy" module with matching platform with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy', platform: 'ios,android' }
+				{ id: 'ti.dummy', platform: 'ios,android' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
+					);
 
-				var found = false;
-				for (var i = 0; !found && i < result.found.length; i++) {
-					if (result.found[i].id === 'dummy') {
-						found = true;
+					var found = false;
+					for (var i = 0; !found && i < result.found.length; i++) {
+						if (result.found[i].id === 'ti.dummy') {
+							found = true;
+						}
 					}
-				}
-				assert(found, '"dummy" module not marked as found');
+					assert(found, '"ti.dummy" module not marked as found');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should find "dummy" module with matching platform with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy', platform: 'ios,android' } ],
+				modules: [ { id: 'ti.dummy', platform: 'ios,android' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -575,19 +649,23 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Found Titanium module id=dummy version=1.2.3 platform=ios deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
+						);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'dummy') {
-							found = true;
+						var found = false;
+						for (var i = 0; !found && i < result.found.length; i++) {
+							if (result.found[i].id === 'ti.dummy') {
+								found = true;
+							}
 						}
-					}
-					assert(found, '"dummy" module not marked as found');
+						assert(found, '"ti.dummy" module not marked as found');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -595,28 +673,32 @@ describe('timodule', function () {
 		it('should ignore "dummy" module with non-matching platform with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'dummy', platform: 'android,mobileweb' }
+				{ id: 'ti.dummy', platform: 'android,mobileweb' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				var found = false;
-				for (let i = 0; !found && i < result.found.length; i++) {
-					found = result.found[i].id === 'dummy';
-				}
-				assert(!found, '"dummy" module was marked as found, should have been ignored');
+				try {
+					var found = false;
+					for (let i = 0; !found && i < result.found.length; i++) {
+						found = result.found[i].id === 'ti.dummy';
+					}
+					assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-				found = false;
-				for (let i = 0; !found && i < result.missing.length; i++) {
-					found = result.missing[i].id === 'dummy';
-				}
-				assert(!found, '"dummy" module was marked as missing, should have been ignored');
+					found = false;
+					for (let i = 0; !found && i < result.missing.length; i++) {
+						found = result.missing[i].id === 'ti.dummy';
+					}
+					assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should ignore "dummy" module with non-matching platform with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'dummy', platform: 'android,mobileweb' } ],
+				modules: [ { id: 'ti.dummy', platform: 'android,mobileweb' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -624,19 +706,23 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					var found = false;
-					for (let i = 0; !found && i < result.found.length; i++) {
-						found = result.found[i].id === 'dummy';
-					}
-					assert(!found, '"dummy" module was marked as found, should have been ignored');
+					try {
+						var found = false;
+						for (let i = 0; !found && i < result.found.length; i++) {
+							found = result.found[i].id === 'ti.dummy';
+						}
+						assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-					found = false;
-					for (let i = 0; !found && i < result.missing.length; i++) {
-						found = result.missing[i].id === 'dummy';
-					}
-					assert(!found, '"dummy" module was marked as missing, should have been ignored');
+						found = false;
+						for (let i = 0; !found && i < result.missing.length; i++) {
+							found = result.missing[i].id === 'ti.dummy';
+						}
+						assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -689,26 +775,30 @@ describe('timodule', function () {
 		it('should find incompatible "toonew" module with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'toonew' }
+				{ id: 'ti.toonew' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found incompatible Titanium module id=toonew version=1.0 platform=ios deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found incompatible Titanium module id=ti.toonew version=1.0 platform=ios deploy-type=development'
+					);
 
-				var found = false;
-				for (var i = 0; !found && i < result.incompatible.length; i++) {
-					found = result.incompatible[i].id === 'toonew';
+					var found = false;
+					for (var i = 0; !found && i < result.incompatible.length; i++) {
+						found = result.incompatible[i].id === 'ti.toonew';
+					}
+					assert(found, '"ti.toonew" module was not marked as incompatible');
+
+					done();
+				} catch (e) {
+					done(e);
 				}
-				assert(found, '"toonew" module was not marked as incompatible');
-
-				done();
 			}, true);
 		});
 
 		it('should find incompatible "toonew" module with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'toonew' } ],
+				modules: [ { id: 'ti.toonew' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -716,17 +806,21 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Found incompatible Titanium module id=toonew version=1.0 platform=ios deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found incompatible Titanium module id=ti.toonew version=1.0 platform=ios deploy-type=development'
+						);
 
-					var found = false;
-					for (var i = 0; !found && i < result.incompatible.length; i++) {
-						found = result.incompatible[i].id === 'toonew';
+						var found = false;
+						for (var i = 0; !found && i < result.incompatible.length; i++) {
+							found = result.incompatible[i].id === 'ti.toonew';
+						}
+						assert(found, '"ti.toonew" module was not marked as incompatible');
+
+						done();
+					} catch (e) {
+						done(e);
 					}
-					assert(found, '"toonew" module was not marked as incompatible');
-
-					done();
 				}
 			});
 		});
@@ -734,22 +828,26 @@ describe('timodule', function () {
 		it('should find conflicting "ambiguous" module with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'ambiguous' }
+				{ id: 'ti.ambiguous' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				var found = false;
-				for (var i = 0; !found && i < result.conflict.length; i++) {
-					found = result.conflict[i].id === 'ambiguous';
-				}
-				assert(found, '"ambiguous" module was not marked as conflict');
+				try {
+					var found = false;
+					for (var i = 0; !found && i < result.conflict.length; i++) {
+						found = result.conflict[i].id === 'ti.ambiguous';
+					}
+					assert(found, '"ti.ambiguous" module was not marked as conflict');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should find conflicting "ambiguous" module with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'ambiguous' } ],
+				modules: [ { id: 'ti.ambiguous' } ],
 				platforms: [ 'ios', 'iphone' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -757,13 +855,17 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					var found = false;
-					for (var i = 0; !found && i < result.conflict.length; i++) {
-						found = result.conflict[i].id === 'ambiguous';
-					}
-					assert(found, '"ambiguous" module was not marked as conflict');
+					try {
+						var found = false;
+						for (var i = 0; !found && i < result.conflict.length; i++) {
+							found = result.conflict[i].id === 'ti.ambiguous';
+						}
+						assert(found, '"ti.ambiguous" module was not marked as conflict');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
@@ -820,28 +922,32 @@ describe('timodule', function () {
 		it('should find the latest valid module with individual params', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find([
-				{ id: 'latestvalid' }
+				{ id: 'ti.latestvalid' }
 			], [ 'commonjs' ], 'development', '3.2.0', [ path.join(__dirname, 'resources', 'timodule3') ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found Titanium module id=latestvalid version=1.0 platform=commonjs deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.latestvalid version=1.0 platform=commonjs deploy-type=development'
+					);
 
-				var found = 0;
-				for (var i = 0; !found && i < result.found.length; i++) {
-					if (result.found[i].id === 'latestvalid') {
-						found++;
+					var found = 0;
+					for (var i = 0; !found && i < result.found.length; i++) {
+						if (result.found[i].id === 'ti.latestvalid') {
+							found++;
+						}
 					}
-				}
-				assert(found === 1, '"latestvalid" module not marked as found');
+					assert(found === 1, '"ti.latestvalid" module not marked as found');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should find the latest valid module with params object', function (done) {
 			var logger = new MockLogger();
 			appc.timodule.find({
-				modules: [ { id: 'latestvalid' } ],
+				modules: [ { id: 'ti.latestvalid' } ],
 				platforms: [ 'commonjs' ],
 				deployType: 'development',
 				sdkVersion: '3.2.0',
@@ -849,21 +955,50 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found Titanium module id=ti.latestvalid version=1.0 platform=commonjs deploy-type=development'
+						);
+
+						var found = 0;
+						for (var i = 0; !found && i < result.found.length; i++) {
+							if (result.found[i].id === 'ti.latestvalid') {
+								found++;
+							}
+						}
+						assert(found === 1, '"ti.latestvalid" module not marked as found');
+
+						done();
+					} catch (e) {
+						done(e);
+					}
+				}
+			});
+		});
+
+		it('should find the latest valid module with iphone/ios mismatch platform', function (done) {
+			var logger = new MockLogger();
+			appc.timodule.find([
+				{ id: 'ti.map' }
+			], [ 'ios' ], 'development', '6.3.0', [ path.join(__dirname, 'resources', 'timodule4') ], logger, function (result) {
+				try {
 					logger.buffer.stripColors.should.containEql(
-						'Found Titanium module id=latestvalid version=1.0 platform=commonjs deploy-type=development'
+						'Found Titanium module id=ti.map version=3.1.0 platform=ios deploy-type=development'
 					);
 
 					var found = 0;
 					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'latestvalid') {
+						if (result.found[i].id === 'ti.map') {
 							found++;
 						}
 					}
-					assert(found === 1, '"latestvalid" module not marked as found');
+					assert(found === 1, '"ti.map" module not marked as found');
 
 					done();
+				} catch (e) {
+					done(e);
 				}
-			});
+			}, true);
 		});
 	});
 

--- a/test/test-timodule.js
+++ b/test/test-timodule.js
@@ -46,11 +46,11 @@ describe('timodule', function () {
 		appc.timodule.should.be.an.Object;
 	});
 
-	var testResourcesDir = path.join(__dirname, 'resources', 'timodule'),
-		dummyModuleDir = path.join(testResourcesDir, 'modules', 'ios', 'dummy', '1.2.3'),
-		toonewModuleDir = path.join(testResourcesDir, 'modules', 'ios', 'toonew', '1.0'),
-		ambiguousModuleDir = path.join(testResourcesDir, 'modules', 'ios', 'ambiguous', '1.0'),
-		ambiguousCommonJSModuleDir = path.join(testResourcesDir, 'modules', 'commonjs', 'ambiguous', '1.0');
+	const testResourcesDir = path.join(__dirname, 'resources', 'timodule');
+	const dummyModuleDir = path.join(testResourcesDir, 'modules', 'ios', 'dummy', '1.2.3');
+	const toonewModuleDir = path.join(testResourcesDir, 'modules', 'ios', 'toonew', '1.0');
+	const ambiguousModuleDir = path.join(testResourcesDir, 'modules', 'ios', 'ambiguous', '1.0');
+	const ambiguousCommonJSModuleDir = path.join(testResourcesDir, 'modules', 'commonjs', 'ambiguous', '1.0');
 
 	describe('#scopedDetect()', function () {
 		it('should return immediately if no paths to search', function (done) {
@@ -156,9 +156,14 @@ describe('timodule', function () {
 	});
 
 	describe('#detect()', function () {
+		let logger;
+
+		beforeEach(() => {
+			logger = new MockLogger();
+		});
+
 		it('should find the test modules with individual params', function (done) {
-			const logger = new MockLogger(),
-				dir = path.join(__dirname, 'resources', 'timodule');
+			const dir = path.join(__dirname, 'resources', 'timodule');
 
 			// we test for dupe search paths, but only one should be searched
 			appc.timodule.detect([ dir, dir ], logger, function (result) {
@@ -190,8 +195,7 @@ describe('timodule', function () {
 		});
 
 		it('should find the test modules with params object', function (done) {
-			const logger = new MockLogger(),
-				dir = path.join(__dirname, 'resources', 'timodule');
+			const dir = path.join(__dirname, 'resources', 'timodule');
 
 			// we test for dupe search paths, but only one should be searched
 			appc.timodule.detect({
@@ -228,7 +232,6 @@ describe('timodule', function () {
 		});
 
 		it('detects native module in node_modules folder under given project path', finished => {
-			const logger = new MockLogger();
 			appc.timodule.detect([ path.join(__dirname, 'resources/npm-native-module') ], logger, result => {
 				try {
 					result.should.be.an.Object;
@@ -256,7 +259,6 @@ describe('timodule', function () {
 		});
 
 		it('combines node_modules and legacy based modules', finished => {
-			const logger = new MockLogger();
 			const dir = path.join(__dirname, 'resources', 'timodule');
 			appc.timodule.detect([ path.join(__dirname, 'resources/npm-native-module'), dir ], logger, result => {
 				try {
@@ -293,8 +295,13 @@ describe('timodule', function () {
 	});
 
 	describe('#find()', function () {
+		let logger;
+
+		beforeEach(() => {
+			logger = new MockLogger();
+		});
+
 		it('should return immediately if no modules with individual params', function (done) {
-			const logger = new MockLogger();
 			appc.timodule.find([], null, null, null, null, logger, function (result) {
 				try {
 					result.should.eql({
@@ -311,7 +318,6 @@ describe('timodule', function () {
 		});
 
 		it('should return immediately if no modules with params object', function (done) {
-			const logger = new MockLogger();
 			appc.timodule.find({
 				modules: [],
 				platforms: null,
@@ -337,7 +343,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module using only the id with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
@@ -346,10 +351,7 @@ describe('timodule', function () {
 						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
 					);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						found = (result.found[i].id === 'ti.dummy');
-					}
+					const found = result.found.find(r => r.id === 'ti.dummy');
 					assert(found, '"ti.dummy" module not marked as found');
 
 					done();
@@ -360,7 +362,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module using only the id with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -375,10 +376,7 @@ describe('timodule', function () {
 							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
 						);
 
-						var found = false;
-						for (var i = 0; !found && i < result.found.length; i++) {
-							found = (result.found[i].id === 'ti.dummy');
-						}
+						const found = result.found.find(r => r.id === 'ti.dummy');
 						assert(found, '"ti.dummy" module not marked as found');
 
 						done();
@@ -390,7 +388,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module with matching version with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy', version: '1.2.3' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
@@ -399,12 +396,7 @@ describe('timodule', function () {
 						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
 					);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'ti.dummy') {
-							found = true;
-						}
-					}
+					const found = result.found.find(r => r.id === 'ti.dummy');
 					assert(found, '"ti.dummy" module not marked as found');
 
 					done();
@@ -415,7 +407,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module with matching version with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy', version: '1.2.3' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -430,12 +421,7 @@ describe('timodule', function () {
 							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
 						);
 
-						var found = false;
-						for (var i = 0; !found && i < result.found.length; i++) {
-							if (result.found[i].id === 'ti.dummy') {
-								found = true;
-							}
-						}
+						const found = result.found.find(r => r.id === 'ti.dummy');
 						assert(found, '"ti.dummy" module not marked as found');
 
 						done();
@@ -447,7 +433,6 @@ describe('timodule', function () {
 		});
 
 		it('should not find "dummy" module with wrong version with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy', version: '3.2.1' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
@@ -456,11 +441,8 @@ describe('timodule', function () {
 						'Could not find a valid Titanium module id=ti.dummy version=3.2.1 platform=ios,commonjs deploy-type=development'
 					);
 
-					var found = false;
-					for (var i = 0; !found && i < result.missing.length; i++) {
-						found = result.missing[i].id === 'ti.dummy';
-					}
-					assert(found, '"ti.dummy" module not marked as missing');
+					const missing = result.missing.find(r => r.id === 'ti.dummy');
+					assert(missing, '"ti.dummy" module not marked as missing');
 
 					done();
 				} catch (e) {
@@ -470,7 +452,6 @@ describe('timodule', function () {
 		});
 
 		it('should not find "dummy" module with wrong version with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy', version: '3.2.1' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -485,11 +466,8 @@ describe('timodule', function () {
 							'Could not find a valid Titanium module id=ti.dummy version=3.2.1 platform=ios,commonjs deploy-type=development'
 						);
 
-						var found = false;
-						for (var i = 0; !found && i < result.missing.length; i++) {
-							found = result.missing[i].id === 'ti.dummy';
-						}
-						assert(found, '"ti.dummy" module not marked as missing');
+						const missing = result.missing.find(r => r.id === 'ti.dummy');
+						assert(missing, '"ti.dummy" module not marked as missing');
 
 						done();
 					} catch (e) {
@@ -500,7 +478,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module with matching deploy type with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy', deployType: 'test,production' }
 			], [ 'ios', 'iphone' ], 'production', '3.2.0', [ testResourcesDir ], logger, function (result) {
@@ -509,12 +486,7 @@ describe('timodule', function () {
 						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=test,production'
 					);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'ti.dummy') {
-							found = true;
-						}
-					}
+					const found = result.found.find(r => r.id === 'ti.dummy');
 					assert(found, '"ti.dummy" module not marked as found');
 
 					done();
@@ -525,7 +497,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module with matching deploy type with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy', deployType: 'test,production' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -540,12 +511,7 @@ describe('timodule', function () {
 							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=test,production'
 						);
 
-						var found = false;
-						for (var i = 0; !found && i < result.found.length; i++) {
-							if (result.found[i].id === 'ti.dummy') {
-								found = true;
-							}
-						}
+						const found = result.found.find(r => r.id === 'ti.dummy');
 						assert(found, '"ti.dummy" module not marked as found');
 
 						done();
@@ -557,22 +523,16 @@ describe('timodule', function () {
 		});
 
 		it('should ignore "dummy" module with non-matching deploy type with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy', deployType: 'test,production' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
 				try {
-					var found = false;
-					for (let i = 0; !found && i < result.found.length; i++) {
-						found = result.found[i].id === 'ti.dummy';
-					}
+
+					const found = result.found.find(r => r.id === 'ti.dummy');
 					assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-					found = false;
-					for (let i = 0; !found && i < result.missing.length; i++) {
-						found = result.missing[i].id === 'ti.dummy';
-					}
-					assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
+					const missing = result.missing.find(r => r.id === 'ti.dummy');
+					assert(!missing, '"ti.dummy" module was marked as missing, should have been ignored');
 
 					done();
 				} catch (e) {
@@ -582,7 +542,6 @@ describe('timodule', function () {
 		});
 
 		it('should ignore "dummy" module with non-matching deploy type with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy', deployType: 'test,production' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -593,17 +552,11 @@ describe('timodule', function () {
 				bypassCache: true,
 				callback: function (result) {
 					try {
-						var found = false;
-						for (let i = 0; !found && i < result.found.length; i++) {
-							found = result.found[i].id === 'ti.dummy';
-						}
+						const found = result.found.find(r => r.id === 'ti.dummy');
 						assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-						found = false;
-						for (let i = 0; !found && i < result.missing.length; i++) {
-							found = result.missing[i].id === 'ti.dummy';
-						}
-						assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
+						const missing = result.missing.find(r => r.id === 'ti.dummy');
+						assert(!missing, '"ti.dummy" module was marked as missing, should have been ignored');
 
 						done();
 					} catch (e) {
@@ -614,7 +567,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module with matching platform with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy', platform: 'ios,android' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
@@ -623,12 +575,7 @@ describe('timodule', function () {
 						'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
 					);
 
-					var found = false;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'ti.dummy') {
-							found = true;
-						}
-					}
+					const found = result.found.find(r => r.id === 'ti.dummy');
 					assert(found, '"ti.dummy" module not marked as found');
 
 					done();
@@ -639,7 +586,6 @@ describe('timodule', function () {
 		});
 
 		it('should find "dummy" module with matching platform with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy', platform: 'ios,android' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -654,12 +600,7 @@ describe('timodule', function () {
 							'Found Titanium module id=ti.dummy version=1.2.3 platform=ios deploy-type=development'
 						);
 
-						var found = false;
-						for (var i = 0; !found && i < result.found.length; i++) {
-							if (result.found[i].id === 'ti.dummy') {
-								found = true;
-							}
-						}
+						const found = result.found.find(r => r.id === 'ti.dummy');
 						assert(found, '"ti.dummy" module not marked as found');
 
 						done();
@@ -671,22 +612,15 @@ describe('timodule', function () {
 		});
 
 		it('should ignore "dummy" module with non-matching platform with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.dummy', platform: 'android,mobileweb' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
 				try {
-					var found = false;
-					for (let i = 0; !found && i < result.found.length; i++) {
-						found = result.found[i].id === 'ti.dummy';
-					}
+					const found = result.found.find(r => r.id === 'ti.dummy');
 					assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-					found = false;
-					for (let i = 0; !found && i < result.missing.length; i++) {
-						found = result.missing[i].id === 'ti.dummy';
-					}
-					assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
+					const missing = result.missing.find(r => r.id === 'ti.dummy');
+					assert(!missing, '"ti.dummy" module was marked as missing, should have been ignored');
 
 					done();
 				} catch (e) {
@@ -696,7 +630,6 @@ describe('timodule', function () {
 		});
 
 		it('should ignore "dummy" module with non-matching platform with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.dummy', platform: 'android,mobileweb' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -707,17 +640,11 @@ describe('timodule', function () {
 				bypassCache: true,
 				callback: function (result) {
 					try {
-						var found = false;
-						for (let i = 0; !found && i < result.found.length; i++) {
-							found = result.found[i].id === 'ti.dummy';
-						}
+						const found = result.found.find(r => r.id === 'ti.dummy');
 						assert(!found, '"ti.dummy" module was marked as found, should have been ignored');
 
-						found = false;
-						for (let i = 0; !found && i < result.missing.length; i++) {
-							found = result.missing[i].id === 'ti.dummy';
-						}
-						assert(!found, '"ti.dummy" module was marked as missing, should have been ignored');
+						const missing = result.missing.find(r => r.id === 'ti.dummy');
+						assert(!missing, '"ti.dummy" module was marked as missing, should have been ignored');
 
 						done();
 					} catch (e) {
@@ -728,26 +655,25 @@ describe('timodule', function () {
 		});
 
 		it('should not find doesnotexist module with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'doesnotexist' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Could not find a valid Titanium module id=doesnotexist version=latest platform=ios,commonjs deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Could not find a valid Titanium module id=doesnotexist version=latest platform=ios,commonjs deploy-type=development'
+					);
 
-				var found = false;
-				for (var i = 0; i < result.missing.length; i++) {
-					found = result.missing[i].id === 'doesnotexist';
+					const missing = result.missing.find(r => r.id === 'doesnotexist');
+					assert(missing, '"doesnotexist" module not marked as missing');
+
+					done();
+				} catch (e) {
+					done(e);
 				}
-				assert(found, '"doesnotexist" module not marked as missing');
-
-				done();
 			}, true);
 		});
 
 		it('should not find doesnotexist module with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'doesnotexist' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -757,23 +683,23 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Could not find a valid Titanium module id=doesnotexist version=latest platform=ios,commonjs deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Could not find a valid Titanium module id=doesnotexist version=latest platform=ios,commonjs deploy-type=development'
+						);
 
-					var found = false;
-					for (var i = 0; i < result.missing.length; i++) {
-						found = result.missing[i].id === 'doesnotexist';
+						const missing = result.missing.find(r => r.id === 'doesnotexist');
+						assert(missing, '"doesnotexist" module not marked as missing');
+
+						done();
+					} catch (e) {
+						done(e);
 					}
-					assert(found, '"doesnotexist" module not marked as missing');
-
-					done();
 				}
 			});
 		});
 
 		it('should find incompatible "toonew" module with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.toonew' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
@@ -782,11 +708,8 @@ describe('timodule', function () {
 						'Found incompatible Titanium module id=ti.toonew version=1.0 platform=ios deploy-type=development'
 					);
 
-					var found = false;
-					for (var i = 0; !found && i < result.incompatible.length; i++) {
-						found = result.incompatible[i].id === 'ti.toonew';
-					}
-					assert(found, '"ti.toonew" module was not marked as incompatible');
+					const incompatible = result.incompatible.find(r => r.id === 'ti.toonew');
+					assert(incompatible, '"ti.toonew" module not marked as incompatible');
 
 					done();
 				} catch (e) {
@@ -796,7 +719,6 @@ describe('timodule', function () {
 		});
 
 		it('should find incompatible "toonew" module with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.toonew' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -811,11 +733,8 @@ describe('timodule', function () {
 							'Found incompatible Titanium module id=ti.toonew version=1.0 platform=ios deploy-type=development'
 						);
 
-						var found = false;
-						for (var i = 0; !found && i < result.incompatible.length; i++) {
-							found = result.incompatible[i].id === 'ti.toonew';
-						}
-						assert(found, '"ti.toonew" module was not marked as incompatible');
+						const incompatible = result.incompatible.find(r => r.id === 'ti.toonew');
+						assert(incompatible, '"ti.toonew" module not marked as incompatible');
 
 						done();
 					} catch (e) {
@@ -826,16 +745,12 @@ describe('timodule', function () {
 		});
 
 		it('should find conflicting "ambiguous" module with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.ambiguous' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir ], logger, function (result) {
 				try {
-					var found = false;
-					for (var i = 0; !found && i < result.conflict.length; i++) {
-						found = result.conflict[i].id === 'ti.ambiguous';
-					}
-					assert(found, '"ti.ambiguous" module was not marked as conflict');
+					const conflict = result.conflict.find(r => r.id === 'ti.ambiguous');
+					assert(conflict, '"ti.ambiguous" module was not marked as conflict');
 
 					done();
 				} catch (e) {
@@ -845,7 +760,6 @@ describe('timodule', function () {
 		});
 
 		it('should find conflicting "ambiguous" module with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.ambiguous' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -856,11 +770,8 @@ describe('timodule', function () {
 				bypassCache: true,
 				callback: function (result) {
 					try {
-						var found = false;
-						for (var i = 0; !found && i < result.conflict.length; i++) {
-							found = result.conflict[i].id === 'ti.ambiguous';
-						}
-						assert(found, '"ti.ambiguous" module was not marked as conflict');
+						const conflict = result.conflict.find(r => r.id === 'ti.ambiguous');
+						assert(conflict, '"ti.ambiguous" module was not marked as conflict');
 
 						done();
 					} catch (e) {
@@ -871,28 +782,30 @@ describe('timodule', function () {
 		});
 
 		it('should find only one "baz" module with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'baz' }
 			], [ 'ios', 'iphone' ], 'development', '3.2.0', [ testResourcesDir, path.join(__dirname, 'resources', 'timodule2') ], logger, function (result) {
-				logger.buffer.stripColors.should.containEql(
-					'Found Titanium module id=baz version=2.0.1 platform=ios deploy-type=development'
-				);
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=baz version=2.0.1 platform=ios deploy-type=development'
+					);
 
-				var found = 0;
-				for (var i = 0; !found && i < result.found.length; i++) {
-					if (result.found[i].id === 'baz') {
-						found++;
+					let found = 0;
+					for (let i = 0; !found && i < result.found.length; i++) {
+						if (result.found[i].id === 'baz') {
+							found++;
+						}
 					}
-				}
-				assert(found === 1, '"baz" module not marked as found');
+					assert(found === 1, '"baz" module not marked as found');
 
-				done();
+					done();
+				} catch (e) {
+					done(e);
+				}
 			}, true);
 		});
 
 		it('should find only one "baz" module with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'baz' } ],
 				platforms: [ 'ios', 'iphone' ],
@@ -902,25 +815,28 @@ describe('timodule', function () {
 				logger: logger,
 				bypassCache: true,
 				callback: function (result) {
-					logger.buffer.stripColors.should.containEql(
-						'Found Titanium module id=baz version=2.0.1 platform=ios deploy-type=development'
-					);
+					try {
+						logger.buffer.stripColors.should.containEql(
+							'Found Titanium module id=baz version=2.0.1 platform=ios deploy-type=development'
+						);
 
-					var found = 0;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'baz') {
-							found++;
+						let found = 0;
+						for (let i = 0; !found && i < result.found.length; i++) {
+							if (result.found[i].id === 'baz') {
+								found++;
+							}
 						}
-					}
-					assert(found === 1, '"baz" module not marked as found');
+						assert(found === 1, '"baz" module not marked as found');
 
-					done();
+						done();
+					} catch (e) {
+						done(e);
+					}
 				}
 			});
 		});
 
 		it('should find the latest valid module with individual params', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.latestvalid' }
 			], [ 'commonjs' ], 'development', '3.2.0', [ path.join(__dirname, 'resources', 'timodule3') ], logger, function (result) {
@@ -929,8 +845,8 @@ describe('timodule', function () {
 						'Found Titanium module id=ti.latestvalid version=1.0 platform=commonjs deploy-type=development'
 					);
 
-					var found = 0;
-					for (var i = 0; !found && i < result.found.length; i++) {
+					let found = 0;
+					for (let i = 0; !found && i < result.found.length; i++) {
 						if (result.found[i].id === 'ti.latestvalid') {
 							found++;
 						}
@@ -945,7 +861,6 @@ describe('timodule', function () {
 		});
 
 		it('should find the latest valid module with params object', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find({
 				modules: [ { id: 'ti.latestvalid' } ],
 				platforms: [ 'commonjs' ],
@@ -960,8 +875,8 @@ describe('timodule', function () {
 							'Found Titanium module id=ti.latestvalid version=1.0 platform=commonjs deploy-type=development'
 						);
 
-						var found = 0;
-						for (var i = 0; !found && i < result.found.length; i++) {
+						let found = 0;
+						for (let i = 0; !found && i < result.found.length; i++) {
 							if (result.found[i].id === 'ti.latestvalid') {
 								found++;
 							}
@@ -977,7 +892,6 @@ describe('timodule', function () {
 		});
 
 		it('should find the latest valid module with iphone/ios mismatch platform', function (done) {
-			var logger = new MockLogger();
 			appc.timodule.find([
 				{ id: 'ti.map' }
 			], [ 'ios' ], 'development', '6.3.0', [ path.join(__dirname, 'resources', 'timodule4') ], logger, function (result) {
@@ -986,13 +900,8 @@ describe('timodule', function () {
 						'Found Titanium module id=ti.map version=3.1.0 platform=ios deploy-type=development'
 					);
 
-					var found = 0;
-					for (var i = 0; !found && i < result.found.length; i++) {
-						if (result.found[i].id === 'ti.map') {
-							found++;
-						}
-					}
-					assert(found === 1, '"ti.map" module not marked as found');
+					const found = result.found.find(r => r.id === 'ti.map');
+					assert(found, '"ti.map" module not marked as found');
 
 					done();
 				} catch (e) {


### PR DESCRIPTION
**Description**:
Using node-appc 0.3.0 via the SDK, our unit test suite is failing to "find" `ti.map` and `ti.touchid`
This is an attempt to fix that issue by adding a test case for it and updating our test suite for timodule.
The core issue seems to be use of the module name to group the entries rather than the id.
I assume this was done primarily for the `titanium` CLi to display the name when listing modules, but it makes
resolution of the modules through the app builds more difficult (and the CLI could easily ask for the display name)

- group modules by id, not name
- Alter test assertions to use module ids rather than names
- clean up test code for timodule