### PR TITLE
fix(ios): handle 'iphone' as desired platform for modules when we normalize to 'ios'

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -167,24 +167,22 @@ function find(modulesOrParams, platforms, deployType, tiManifest, searchPaths, l
 				// make sure the module has a valid array of platforms
 				module.platform || (module.platform = params.platforms);
 				Array.isArray(module.platform) || (module.platform = module.platform.split(','));
+				// align 'iphone'/'ipad'/'ios' => 'ios'
+				module.platform = Array.from(new Set(module.platform.map(p => platformAliases[p] || p)));
 
 				module.deployType || (module.deployType = params.deployType);
 				Array.isArray(module.deployType) || (module.deployType = module.deployType.split(','));
 
 				// if this module doesn't support any of the platforms we're building for, skip it
-				if (module.deployType.indexOf(params.deployType) === -1
-					|| !module.platform.some(function (a) {
-						return params.platforms.indexOf(a) !== -1;
-					})) {
+				if (!module.deployType.includes(params.deployType)
+					|| !module.platform.some(platform => params.platforms.includes(platform))) {
 					return;
 				}
 
 				// strip all platforms that aren't supported by this build
 				for (let i = 0; i < module.platform.length; i++) {
-					if (params.platforms.indexOf(module.platform[i]) === -1) {
-						module.platform.splice(i--, 1);
-					} else if (platformAliases[module.platform[i]] && module.platform.indexOf(platformAliases[module.platform[i]]) === -1) {
-						module.platform.push(platformAliases[module.platform[i]]);
+					if (!params.platforms.includes(module.platform[i])) {
+						module.platform.splice(i--, 1); // we're not asking for this platform, remove it
 					}
 				}
 
@@ -257,7 +255,7 @@ function find(modulesOrParams, platforms, deployType, tiManifest, searchPaths, l
 											foundBetter = true;
 										} else if (version.eq(result.found[k].version, ver)) {
 											alreadyAdded = true;
-											if (result.found[k].platform.map(function (p) { return platformAliases[p] || p; }).indexOf(platformAliases[platform] || platform) !== -1) { // eslint-disable-line max-statements-per-line
+											if (result.found[k].platform.map(p => platformAliases[p] || p).includes(platformAliases[platform] || platform)) { // eslint-disable-line max-statements-per-line
 												addToModuleMap = false;
 											}
 										} else {
@@ -265,7 +263,7 @@ function find(modulesOrParams, platforms, deployType, tiManifest, searchPaths, l
 										}
 									} else if (version.eq(result.found[k].version, ver)) {
 										alreadyAdded = true;
-										if (result.found[k].platform.indexOf(platformAliases[platform] || platform) !== -1) {
+										if (result.found[k].platform.includes(platformAliases[platform] || platform)) {
 											addToModuleMap = false;
 										}
 									}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-appc",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "appcelerator"
   ],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "npmjs@appcelerator.com"

--- a/test/test-timodule.js
+++ b/test/test-timodule.js
@@ -909,6 +909,25 @@ describe('timodule', function () {
 				}
 			}, true);
 		});
+
+		it('should find the latest valid module with iphone/ios mismatch platform 2', function (done) {
+			appc.timodule.find([
+				{ id: 'ti.map', platform: 'iphone' }
+			], [ 'iphone' ], 'development', '6.3.0', [ path.join(__dirname, 'resources', 'timodule4') ], logger, function (result) {
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.map version=3.1.0 platform=ios deploy-type=development'
+					);
+
+					const found = result.found.find(r => r.id === 'ti.map');
+					assert(found, '"ti.map" module not marked as found');
+
+					done();
+				} catch (e) {
+					done(e);
+				}
+			}, true);
+		});
 	});
 
 	describe('#detectNodeModules()', () => {


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-27040

**Description**:
As noted in #148, we "normalize" modules to report 'iOS' in place of 'iphone' or 'ipad' in their platform array when detecting. The issue was that I did not also normalize all the possible input platforms to `#find()` to do the same. I normalized the array of platforms, but not the individual module object's platforms arrays.

So, if you did:
```javascript
appc.timodule.find([ { id: 'ti.map', platform: 'iphone' } ], [ 'iphone' ], 'development', '6.3.0' // etc
```

I'd normalize the second argument `[ 'iphone' ]` to be `'ios'` under the hood but not the entries in the first: `[ { id: 'ti.map', platform: 'iphone' } ]`. What resulted is that we silently did not look for modules with platform 'iphone' or 'ipad' in the tiapp.xml.