### PR TITLE
allow platform from manifest to overwrite platform

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -710,7 +710,7 @@ async function detectNativeModuleViaNPMPackage(singlePackageDir, logger) {
  * @returns {object} the detected module
  */
 async function detectPlatformSpecificNativeModuleInNPMPackage(directory, platformName, platformCount, json, logger) {
-	const platform = platformAliases[platformName] || platformName; // normalize platform name for return data
+	let platform = platformAliases[platformName] || platformName; // normalize platform name for return data
 	let modulePath = path.join(directory, platform); // try the normalized platform alias ('ios') first
 	if (!await fs.exists(modulePath)) {
 		// doesn't exist, so fall back to original platform name if it differed
@@ -744,6 +744,7 @@ async function detectPlatformSpecificNativeModuleInNPMPackage(directory, platfor
 	// TODO: Throw a sanity Error if value we *must* have are missing from manifest object!
 	// TODO: Throw Errors is both manifest and package.json have values but they don't match?
 
+	platform = manifest.platform || platform;
 	logger && logger.debug(__('Detected %s module: %s %s @ %s', platform, manifest.moduleid.cyan, json.version, modulePath));
 	return {
 		id: manifest.moduleid,


### PR DESCRIPTION
This change allows for the `platform `property in the manifest to override anything that was passed in from `package.json`.

The reason for this is the current code does not allow the native module to exist in a sub-directory of the package.  This can conflict with Alloy code with gives meaning to the `ios` and `android` directories.  If those directories are needed for the JavaScript files, there will be a conflict.

With the code change, you can now specify a `package.json` with a `titanium` property like this:

```
  "titanium": {
	  "type": "native-module",
	  "platform": ["modules/ios", "modules/android"]
  }
``` 

where the native modules exist in a sub-directory named `modules`.