### PR TITLE
Fix inconsistensies in module detection

### DIFF
--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -230,7 +230,10 @@ function find(modulesOrParams, platforms, deployType, tiManifest, searchPaths, l
 								return;
 							}
 
-							const platformAPIVersion = moduleAPIVersion && moduleAPIVersion[platform] && parseInt(moduleAPIVersion[platform], 10);
+							let platformAPIVersion = moduleAPIVersion && moduleAPIVersion[platform] && parseInt(moduleAPIVersion[platform], 10);
+							if (!platformAPIVersion && platform === 'ios') {
+								platformAPIVersion =  moduleAPIVersion && moduleAPIVersion['iphone'] && parseInt(moduleAPIVersion['iphone'], 10);
+							}
 							const modAPIVersion = info.manifest && parseInt(info.manifest.apiversion, 10);
 							if (platformAPIVersion && modAPIVersion && modAPIVersion !== platformAPIVersion) {
 								if (params.logger) {

--- a/lib/timodule.js
+++ b/lib/timodule.js
@@ -230,10 +230,12 @@ function find(modulesOrParams, platforms, deployType, tiManifest, searchPaths, l
 								return;
 							}
 
-							if (moduleAPIVersion && moduleAPIVersion[platform] && info.manifest && info.manifest.apiversion && info.manifest.apiversion !== moduleAPIVersion[platform]) {
+							const platformAPIVersion = moduleAPIVersion && moduleAPIVersion[platform] && parseInt(moduleAPIVersion[platform], 10);
+							const modAPIVersion = info.manifest && parseInt(info.manifest.apiversion, 10);
+							if (platformAPIVersion && modAPIVersion && modAPIVersion !== platformAPIVersion) {
 								if (params.logger) {
 									params.logger.debug(__('Found incompatible Titanium module id=%s version=%s platform=%s api-version=%s deploy-type=%s', tmp.id.cyan, tmp.version.cyan, tmp.platform.join(',').cyan, String(info.manifest.apiversion).cyan, tmp.deployType.join(',').cyan));
-									params.logger.debug(__('Module %s has apiversion=%s, but the selected SDK supports module apiversion=%s on platform=%s', tmp.id.cyan, info.manifest.apiversion.cyan, moduleAPIVersion[platform].cyan, platform.cyan));
+									params.logger.debug(__('Module %s has apiversion=%s, but the selected SDK supports module apiversion=%s on platform=%s', tmp.id.cyan, String(modAPIVersion).cyan, String(platformAPIVersion).cyan, platform.cyan));
 								}
 								result.incompatible.push(tmp);
 								foundIncompatible = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-appc",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "appcelerator"
   ],
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "npmjs@appcelerator.com"

--- a/test/resources/timodule5/modules/android/ti.map/3.1.0/manifest
+++ b/test/resources/timodule5/modules/android/ti.map/3.1.0/manifest
@@ -1,0 +1,18 @@
+#
+# this is your module manifest and used by Titanium
+# during compilation, packaging, distribution, etc.
+#
+version: 3.1.0
+apiversion: 2
+architectures: arm64-v8a armeabi-v7a x86
+description: External version of Map module
+author: Jeff Haynie, Jon Alter, Pedro Enrique, Hans Knöchel, Vijay Singh
+license: Apache Public License v2
+copyright: Copyright (c) 2013-present by Axway Appcelerator
+
+# these should not be edited
+name: map
+moduleid: ti.map
+guid: fee93b77-8eb3-418c-8f04-013664c4af83
+platform: android
+minsdk: 6.2.2.GA

--- a/test/test-timodule.js
+++ b/test/test-timodule.js
@@ -947,6 +947,28 @@ describe('timodule', function () {
 				}
 			}, true);
 		});
+
+		it('should check apiversion for iphone if no ios value', function (done) {
+			appc.timodule.find([
+				{ id: 'cross-platform-with-manifest', platform: 'iphone' }
+			], [ 'iphone' ], 'development', { sdkVersion: '6.3.0', moduleAPIVersion: { iphone: '2' } }, [ path.join(__dirname, 'resources', 'cross-platform-native-module-with-manifest') ], logger, function (result) {
+				try {
+					console.log(logger.buffer.stripColors);
+					logger.buffer.stripColors.should.containEql(
+						'Found incompatible Titanium module id=cross-platform-with-manifest version=2.0.1 platform=ios api-version=1 deploy-type=development'
+					);
+
+					logger.buffer.stripColors.should.containEql(
+						'Module cross-platform-with-manifest has apiversion=1, but the selected SDK supports module apiversion=2 on platform=ios'
+					);
+
+					assert(result.found.length === 0, '"cross-platform-with-manifest" module was marked as found');
+					done();
+				} catch (e) {
+					done(e);
+				}
+			}, true);
+		});
 	});
 
 	describe('#detectNodeModules()', () => {

--- a/test/test-timodule.js
+++ b/test/test-timodule.js
@@ -928,6 +928,25 @@ describe('timodule', function () {
 				}
 			}, true);
 		});
+
+		it('should parse apiversion to an integer before comparing', function (done) {
+			appc.timodule.find([
+				{ id: 'ti.map', platform: 'android' }
+			], [ 'android' ], 'development', { sdkVersion: '6.3.0', moduleAPIVersion: { android: 2 } }, [ path.join(__dirname, 'resources', 'timodule5') ], logger, function (result) {
+				try {
+					logger.buffer.stripColors.should.containEql(
+						'Found Titanium module id=ti.map version=3.1.0 platform=android deploy-type=development'
+					);
+
+					const found = result.found.find(r => r.id === 'ti.map');
+					assert(found, '"ti.map" module not marked as found');
+
+					done();
+				} catch (e) {
+					done(e);
+				}
+			}, true);
+		});
 	});
 
 	describe('#detectNodeModules()', () => {


### PR DESCRIPTION
c670fc5f98529e9dd85ef5be7db1153d2953315e [TIMOB-27203](https://jira.appcelerator.org/browse/TIMOB-27203) - iOS: no apiversion validation performed on application build

2974e523442326883bb08464bc460414fd8c3c68 [TIMOB-27204](https://jira.appcelerator.org/browse/TIMOB-27204) - CLI: apiversion validation always fails for native modules installed via npm

Commits should be structured so this can be "Rebase and merged"