### PR TITLE
fix(analytics): cast process.pid to string before writing to file

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -280,7 +280,7 @@ process.on('message', function (args) {
 
 	// write the pid file
 	logger.debug(__('Writing new pid file: %s', String(process.pid).cyan));
-	fs.writeFileSync(pidFile, process.pid);
+	fs.writeFileSync(pidFile, String(process.pid));
 
 	// send the analytics events, if any
 	var files = fs.readdirSync(eventsDir);


### PR DESCRIPTION
Fixes an issue seen when I tried running master of the SDK unit tests on Node 14:
```
(node:24204) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
internal/fs/utils.js:714
  throw new ERR_INVALID_ARG_TYPE(
  ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (24209)
    at Object.writeFileSync (fs.js:1429:5)
    at process.<anonymous> (/Users/cwilliams/repos/titanium_mobile/node_modules/titanium/node_modules/node-appc/lib/analytics.js:283:5)
    at process.emit (events.js:314:20)
    at emit (internal/child_process.js:902:12)
    at processTicksAndRejections (internal/process/task_queues.js:81:21) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

We cast the `process.pid` to `String` explicitly to make it happy.